### PR TITLE
Fix issue of `didChange` for null range change.

### DIFF
--- a/src/main/java/org/javacs/JavaTextDocumentService.java
+++ b/src/main/java/org/javacs/JavaTextDocumentService.java
@@ -541,7 +541,7 @@ class JavaTextDocumentService implements TextDocumentService {
             if (document.getVersion() > existing.version) {
                 for (var change : params.getContentChanges()) {
                     if (change.getRange() == null)
-                        activeDocuments.put(uri, new VersionedContent(change.getText(), document.getVersion()));
+                        newText = change.getText();
                     else newText = patch(newText, change);
                 }
 


### PR DESCRIPTION
When only one change is happened, and `change.getRange() == null`, so a new version content will be put into activeDocuments.
However, later `newText` will still overwrite this version. Unfortunately, in this case, `newText` will be `existing.content`.
So in this case, the existing content will be put into activeDocuments in the end.