### PR TITLE
Build fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,38 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Configure fat jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.1</version>
+                <configuration>
+                    <outputFile>${project.basedir}/target/javac-services-${project.version}-with-dependencies.jar</outputFile>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.javacs.Main</mainClass>
+                        </transformer>
+                    </transformers>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### What
Build fat jar.

### Why
In 9a02922e98d84bb1ea0b19ff8d2259b5cb7b0e9c the fat jar was removed and replaced with scripts to jlink a self-contained distribution. While jlink is very cool new functionality, a self contained fat jar can be more convenient for some folks and it would be helpful for users where a fat jar is simpler if one was still generated. The time cost during packaging to generate a fat jar is very small so I don't expect this to have any negative impact on folks who don't need it. This is especially helpful for users of the java-language-server who are using it standalone.

### Related
- #51
- #58 