### PR TITLE
Add '--quiet' option for standalone usage

### DIFF
--- a/src/main/java/org/javacs/Main.java
+++ b/src/main/java/org/javacs/Main.java
@@ -1,5 +1,6 @@
 package org.javacs;
 
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.javacs.lsp.*;
@@ -18,6 +19,12 @@ public class Main {
     }
 
     public static void main(String[] args) {
+        boolean quiet = Arrays.stream(args).anyMatch("--quiet"::equals);
+
+        if (quiet) {
+          LOG.setLevel(Level.OFF);
+        }
+
         try {
             // Logger.getLogger("").addHandler(new FileHandler("javacs.%u.log", false));
             setRootFormat();


### PR DESCRIPTION
What
===
Add '--quiet' option for standalone usage. When provided the logger will
be turned off resulting in no information writing to stderr.

Why
===
When using standalone with IDEs like vim and plugins like vim-lsc the
stderr of the command will be outputted into the terminal. This tool is
pretty noisy and writes a lot of information which is great for
development of the tool but not when using it day-to-day.