### PR TITLE
Add installation instructions for vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 # Language Server for Java using the [Java compiler API](https://docs.oracle.com/javase/10/docs/api/jdk.compiler-summary.html) 
 
-A Java [language server](https://github.com/Microsoft/vscode-languageserver-protocol) implemented using the Java compiler API. 
+A Java [language server](https://github.com/Microsoft/vscode-languageserver-protocol) based on v3.0 of the protocol and implemented using the Java compiler API. 
 
 [![CircleCI](https://circleci.com/gh/georgewfraser/java-language-server.png)](https://circleci.com/gh/georgewfraser/java-language-server)
 
-## Installation
+## Installation (VS Code)
 
 [Install from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=georgewfraser.vscode-javac)
+
+## Installation (other editors)
+
+### Vim (with vim-lsc)
+
+- Checkout this repository
+- Run `./scripts/link_mac.sh`
+- Add the vim plugin [natebosch/vim-lsc](https://github.com/natebosch/vim-lsc) to your vimrc
+- Add vim-lsc configuration:
+  ```vimrc
+  let g:lsc_server_commands = {'java': '<path-to-java-language-server>/java-language-server/dist/mac/bin/launcher --quiet'}
+  ```
+- See the [vim-lsc README](https://github.com/natebosch/vim-lsc/blob/master/README.md) for other configuration options.
+
+Note: This tool is not compatible with [vim-lsp](https://github.com/prabirshrestha/vim-lsp) as it only supports LSPv2.0.
 
 ## [Issues](https://github.com/georgewfraser/java-language-server/issues)
 


### PR DESCRIPTION
### What
Add installation instructions for vim using the vim plugin vim-lsc.

### Why
This tool works great in vim but it isn't straight forward setting it
up. These instructions will help others get off the ground using this
tool with vim.

### Notes
- These instructions assume #79 is merged that adds `--quiet`.
- I added the call out that this server is using version 3.0 of the
language server protocol. Mentioning that isn't really required,
but I think it's helpful to call out because there are several tools
out there now that only interact with v2.0 servers. The main
difference being that the `initialized` event is never sent which
causes some servers, e.g. this one, not to be in the right state.