### PR TITLE
Make javaLsFlag.txt and lib/src.zip optional

### DIFF
--- a/src/main/java/org/javacs/Docs.java
+++ b/src/main/java/org/javacs/Docs.java
@@ -15,10 +15,13 @@ public class Docs {
     /** File manager with source-path + platform sources, which we will use to look up individual source files */
     private final SourceFileManager fileManager = new SourceFileManager();
 
-    private static Path srcZip() {
+    private static Optional<Path> srcZip() {
+        if (!Lib.SRC_ZIP.isPresent()) {
+          return Optional.empty();
+        }
         try {
-            var fs = FileSystems.newFileSystem(Lib.SRC_ZIP, Docs.class.getClassLoader());
-            return fs.getPath("/");
+            var fs = FileSystems.newFileSystem(Lib.SRC_ZIP.get(), Docs.class.getClassLoader());
+            return Optional.of(fs.getPath("/"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -30,7 +33,10 @@ public class Docs {
 
         try {
             fileManager.setLocation(StandardLocation.SOURCE_PATH, sourcePathFiles);
-            fileManager.setLocationFromPaths(StandardLocation.MODULE_SOURCE_PATH, Set.of(srcZip()));
+            Optional<Path> srcZipPath = srcZip();
+            if (srcZipPath.isPresent()) {
+              fileManager.setLocationFromPaths(StandardLocation.MODULE_SOURCE_PATH, Set.of(srcZipPath.get()));
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/javacs/Lib.java
+++ b/src/main/java/org/javacs/Lib.java
@@ -1,15 +1,15 @@
 package org.javacs;
 
+import java.util.Optional;
 import java.nio.file.*;
 
 class Lib {
-    static Path installRoot() {
+    static Optional<Path> installRoot() {
         var root = Paths.get(".").toAbsolutePath();
         var p = root;
         while (p != null && !Files.exists(p.resolve("javaLsFlag.txt"))) p = p.getParent();
-        if (p == null) throw new RuntimeException("Couldn't find javaLsFlag.txt in any parent of " + root);
-        return p;
+        return Optional.ofNullable(p);
     }
 
-    static final Path SRC_ZIP = installRoot().resolve("lib/src.zip");
+    static final Optional<Path> SRC_ZIP = installRoot().map(path -> path.resolve("lib/src.zip"));
 }


### PR DESCRIPTION
What
===
Make javaLsFlag.txt and lib/src.zip optional.

Why
===
When using this tool standalone the lib/src.zip file doesn't seem to be
packaged inside what is jlinked and exceptions are raised because it
cannot be found. From the tests I've run it doesn't seem to make any
difference if the zip file is present or not, at least to the features I
am using. I don't really understand what the txt and zip file are for,
but it seems like this language server protocol can be used without
them.