### PR TITLE
Remove src.zip and get it from JAVA_HOME

### DIFF
--- a/javaLsFlag.txt
+++ b/javaLsFlag.txt
@@ -1,1 +1,0 @@
-This file is a flag to help Lib#installRoot find the root directory of the extension.

--- a/src/main/java/org/javacs/Docs.java
+++ b/src/main/java/org/javacs/Docs.java
@@ -15,10 +15,13 @@ public class Docs {
     /** File manager with source-path + platform sources, which we will use to look up individual source files */
     private final SourceFileManager fileManager = new SourceFileManager();
 
-    private static Path srcZip() {
+    private static Optional<Path> srcZip() {
+        if (!Lib.SRC_ZIP.isPresent()) {
+            return Optional.empty();
+        }
         try {
-            var fs = FileSystems.newFileSystem(Lib.SRC_ZIP, Docs.class.getClassLoader());
-            return fs.getPath("/");
+            var fs = FileSystems.newFileSystem(Lib.SRC_ZIP.get(), Docs.class.getClassLoader());
+            return Optional.of(fs.getPath("/"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -30,7 +33,10 @@ public class Docs {
 
         try {
             fileManager.setLocation(StandardLocation.SOURCE_PATH, sourcePathFiles);
-            fileManager.setLocationFromPaths(StandardLocation.MODULE_SOURCE_PATH, Set.of(srcZip()));
+            Optional<Path> srcZipPath = srcZip();
+            if (srcZipPath.isPresent()) {
+                fileManager.setLocationFromPaths(StandardLocation.MODULE_SOURCE_PATH, Set.of(srcZipPath.get()));
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/javacs/Lib.java
+++ b/src/main/java/org/javacs/Lib.java
@@ -1,15 +1,22 @@
 package org.javacs;
 
+import java.io.File;
+import java.lang.System;
+import java.util.Optional;
 import java.nio.file.*;
 
 class Lib {
-    static Path installRoot() {
-        var root = Paths.get(".").toAbsolutePath();
-        var p = root;
-        while (p != null && !Files.exists(p.resolve("javaLsFlag.txt"))) p = p.getParent();
-        if (p == null) throw new RuntimeException("Couldn't find javaLsFlag.txt in any parent of " + root);
-        return p;
+    static Optional<Path> srcZipPath() {
+        return Optional.ofNullable(System.getenv("JAVA_HOME"))
+            .flatMap(home -> Optional.of(Paths.get(home).resolve("lib/src.zip")))
+            .flatMap(path -> {
+                if (path.toFile().exists()) {
+                    return Optional.of(path);
+                } else {
+                    return Optional.empty();
+                }
+            });
     }
 
-    static final Path SRC_ZIP = installRoot().resolve("lib/src.zip");
+    static final Optional<Path> SRC_ZIP = srcZipPath();
 }


### PR DESCRIPTION
### What
Remove src.zip and get it from the path pointed to by the JAVA_HOME
environment variable.

### Why
When using this tool standalone the lib/src.zip file doesn't seem to be
packaged inside what is jlinked which causes exceptions on startup. It
also seems odd to package src.zip inside the tool when Java JDK
installations come with src, and in the event they don't (e.g.  OpenJDK
on Debian) they can be easily installed using the distros built in
package manager.

As a side note the src.zip licensing is ambiguous to me and it's not
clear from any other documentation in this repository how it is being
licensed. I assume it is properly licensed to have been included, but
regardless removing any licensing ambiguity from the tool seems ideal
for those using it.

### Related
- https://github.com/georgewfraser/java-language-server/pull/81#issuecomment-464942602