### PR TITLE
Fix bug where server blocks clients during shutdown

### DIFF
--- a/src/main/java/org/javacs/lsp/LSP.java
+++ b/src/main/java/org/javacs/lsp/LSP.java
@@ -242,6 +242,7 @@ public class LSP {
                     case "shutdown":
                         {
                             LOG.warning("Got shutdown message");
+                            respond(send, r.id, null);
                             break;
                         }
                     case "exit":


### PR DESCRIPTION
### What
Respond to shutdown request with an empty result.

### Why
The server does not respond to the shutdown request. Clients expect a
response to the shutdown request before they issue the exit request.
This is to give the server time to shutdown properly before the client
also shuts down. In IDE clients that follow this pattern properly, e.g.
vim-lsc, it can cause the IDE to lock up and wait for a response until a
timeout occurs. It's possible this is a problem in multi-threaded IDEs
(e.g. VS Code) too and the effects of it may be hidden by background
threads.

### Note
The response has been implemented based off the LSP v3.0 specification.
The result in the response is null.

### References
https://microsoft.github.io/language-server-protocol/specification#shutdown