### PR TITLE
Remove '.hover' from the language on code hover

### DIFF
--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -644,7 +644,7 @@ class JavaLanguageServer extends LanguageServer {
         // Add code hover message
         var result = new ArrayList<MarkedString>();
         var code = hoverCode(el.get());
-        result.add(new MarkedString("java.hover", code));
+        result.add(new MarkedString("java", code));
         // Add docs hover message
         var docs = hoverDocs(el.get());
         if (docs.isPresent()) {


### PR DESCRIPTION
What
===
Remove '.hover' from the language name on code hover so language is set
as `java` instead of `java.hover`.

Why
===
The intention of the language is to display it in GitHub's markdown
fenced code block format. The '.hover' is unnecessary noise as only the
'java' is required to correctly satisfy the syntax of the fenced code
block.