### PR TITLE
Display docs correctly in hover

### DIFF
--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -644,7 +644,7 @@ class JavaLanguageServer extends LanguageServer {
         // Add code hover message
         var result = new ArrayList<MarkedString>();
         var code = hoverCode(el.get());
-        result.add(new MarkedString("java.hover", code));
+        result.add(new MarkedString("java", code));
         // Add docs hover message
         var docs = hoverDocs(el.get());
         if (docs.isPresent()) {

--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -645,9 +646,9 @@ class JavaLanguageServer extends LanguageServer {
 
         // Add docs hover message
         var docs = hoverDocs(el.get());
-        if (docs.isPresent()) {
-            result.add(new MarkedString(docs.get()));
-        }
+        docs.filter(Predicate.not(String::isBlank)).ifPresent(doc -> {
+            result.add(new MarkedString(doc));
+        });
 
         // Add code hover message
         var code = hoverCode(el.get());

--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -641,15 +641,17 @@ class JavaLanguageServer extends LanguageServer {
         var el = activeFileCache.element(line, column);
         if (!el.isPresent()) return Optional.empty();
 
-        // Add code hover message
         var result = new ArrayList<MarkedString>();
-        var code = hoverCode(el.get());
-        result.add(new MarkedString("java", code));
+
         // Add docs hover message
         var docs = hoverDocs(el.get());
         if (docs.isPresent()) {
-            result.add(new MarkedString("markdown", docs.get()));
+            result.add(new MarkedString(docs.get()));
         }
+
+        // Add code hover message
+        var code = hoverCode(el.get());
+        result.add(new MarkedString("java", code));
 
         return Optional.of(new Hover(result));
     }

--- a/src/main/java/org/javacs/lsp/MarkedString.java
+++ b/src/main/java/org/javacs/lsp/MarkedString.java
@@ -1,12 +1,46 @@
 package org.javacs.lsp;
 
+import java.io.IOException;
+
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.TypeAdapter;
+
+@JsonAdapter(MarkedString.Adapter.class)
 public class MarkedString {
     public String language, value;
 
     public MarkedString() {}
 
+    public MarkedString(String value) {
+        this.value = value;
+    }
+
     public MarkedString(String language, String value) {
         this.language = language;
         this.value = value;
+    }
+
+    public static class Adapter extends TypeAdapter<MarkedString> {
+        @Override
+        public void write(JsonWriter out, MarkedString markedString) throws IOException {
+            if (markedString.language == null) {
+                out.value(markedString.value);
+            } else {
+                out.beginObject();
+                out.name("language");
+                out.value(markedString.language);
+                out.name("value");
+                out.value(markedString.value);
+                out.endObject();
+            }
+        }
+
+        @Override
+        public MarkedString read(JsonReader reader) throws IOException {
+          throw new UnsupportedOperationException("Deserializing MarkedString's is unsupported.");
+        }
     }
 }


### PR DESCRIPTION
What
===
Display docs are plaintext in hover, instead of inside a GitHub markdown fenced markdown code block.

Why
===
Hover text can be made up of multiple MarkedStrings where a MarkedString is either plaintext, or a codeblock for a code language. Docs are usually intended to be displayed as plaintext (in markdown), with the code blocks included alongside it. The docs shouldn't be returned as one of the code blocks.

Also
===
There is also two minor improvements included with this change:
1. Plaintext docs are inserted above the code block, which presents the docs more consistently like the examples in the language server protocol specification. This also looks better in clients because the docs one-liner is often only one line, but the code blocks are often huge, so it stops the docs from being pushed all the way to the bottom.
2. If the docs returned are present but blank, don't send them back to the client, as some clients will insert a blank empty line. There's no reason to include an empty MarkedString if the docs are blank.

Reference
===
https://microsoft.github.io/language-server-protocol/specification#textDocument_hover