### PR TITLE
Support other locations for finding src.zip

### DIFF
--- a/src/main/java/org/javacs/Lib.java
+++ b/src/main/java/org/javacs/Lib.java
@@ -3,18 +3,25 @@ package org.javacs;
 import java.io.File;
 import java.lang.System;
 import java.util.Optional;
+import java.util.Arrays;
 import java.nio.file.*;
 
 class Lib {
     static Optional<Path> srcZipPath() {
         return Optional.ofNullable(System.getenv("JAVA_HOME"))
-            .flatMap(home -> Optional.of(Paths.get(home).resolve("lib/src.zip")))
-            .flatMap(path -> {
-                if (path.toFile().exists()) {
-                    return Optional.of(path);
-                } else {
-                    return Optional.empty();
+            .map(home -> {
+                return Arrays.asList(new Path[]{
+                    Paths.get(home).resolve("lib/src.zip"),
+                    Paths.get(home).resolve("src.zip"),
+                });
+            })
+            .flatMap(paths -> {
+                for (Path path : paths) {
+                    if (path.toFile().exists()) {
+                        return Optional.of(path);
+                    }
                 }
+                return Optional.empty();
             });
     }
 


### PR DESCRIPTION
What
===
Support other locations for finding src.zip so that it is found it if
lives at either:
 - JAVA_HOME/lib/src.zip
 - JAVA_HOME/src.zip

Why
===
I've observed in testing that some installations of JVMs include src.zip
in the root, others in a lib/src.zip.