### PR TITLE
Allow JDK versions higher than 11

### DIFF
--- a/scripts/check_java_home.sh
+++ b/scripts/check_java_home.sh
@@ -16,9 +16,9 @@ if [ ! -f "$JAVA_HOME/bin/java" ]; then
 fi
 
 java_version=$("$JAVA_HOME/bin/java" -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*".*/\1/p;')
-if [ "$java_version" -ne 11 ]; then
+if [ "$java_version" -lt 11 ]; then
   echo "JAVA_HOME is set to: $JAVA_HOME"
   echo "JAVA_HOME version is: $java_version"
-  echo "JAVA_HOME must be set to a JDK version 11"
+  echo "JAVA_HOME must be set to a JDK version >=11"
   exit 1
 fi


### PR DESCRIPTION
Hello there.

I am using `java-language-server` for [Android](https://github.com/hsanson/vim-android) development with Vim on Parabola (Arch Linux) through the AUR [stable](https://aur.archlinux.org/packages/java-language-server/) and [git](https://aur.archlinux.org/packages/java-language-server-git/) packages.

I tried building `java-language-server` with OpenJDK 12 and it seems to be working just fine.

This PR contains a proposal to allow linking with JDK versions equal or higher than 11.

What are your thoughts? Thank you for your time.