### PR TITLE
Correctly verify that directory witch ends with `.java` is not a java file.

### DIFF
--- a/src/main/java/org/javacs/FileStore.java
+++ b/src/main/java/org/javacs/FileStore.java
@@ -311,7 +311,7 @@ class FileStore {
         // because it doesn't realize there are already up-to-date .class files.
         // The better solution would be for java-language server to detect the presence of module-info.java,
         // and go into its own "module mode" where it infers a module source path and a module class path.
-        return name.endsWith(".java") && !name.equals("module-info.java");
+        return name.endsWith(".java") && !Files.isDirectory(file) &&  !name.equals("module-info.java");
     }
 
     static boolean isJavaFile(URI uri) {


### PR DESCRIPTION
`FileStore::isJavaFile` verifies only that path name ends with `.java`. In case that path is a directory with name for example `lib.java` this cause IOException which cause that server could not initialize itself. To mitigate that this pull request additionally verifies if path point to file.