### PR TITLE
Fail quietly on MalformedInputException when parsing package name

### DIFF
--- a/src/main/java/org/javacs/StringSearch.java
+++ b/src/main/java/org/javacs/StringSearch.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.MalformedInputException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Comparator;
@@ -487,6 +488,8 @@ class StringSearch {
                     return id;
                 }
             }
+        } catch (MalformedInputException e) {
+            LOG.warning("Malformed input in file " + file.toString() + ": " + e.getMessage());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
When searching for Java files, it's possible to find a `.java` file with
invalid contents, such as in the case of a Vim undo file. When this
happens, a MalformedInputException is thrown, causing initialization to
fail. In this case, it would be better to quietly ignore the failure
than to abort entirely.