### PR TITLE
Update import order on format

### DIFF
--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -1035,7 +1035,8 @@ class JavaLanguageServer extends LanguageServer {
         }
         // Insert each import
         for (var i : imports) {
-            insertText.append("import ").append(i).append(";\n");
+            if (i != null) insertText.append("import ").append(i).append(";");
+            insertText.append("\n");
         }
         var insertPosition = new Position((int) insertLine, 0);
         var insert = new TextEdit(new Range(insertPosition, insertPosition), insertText.toString());


### PR DESCRIPTION
This commit updates the `textDocument/formatting` call to group imports
according to the following rules:

1. `java` and `javax` imports up top.
2. Known top-level domains are grouped alphabetically below that (`com`,
   `io`, and `org`), and are further grouped by their second package name
   element.
3. Packages not matching any of the above are considered local to the
   project, and grouped at the bottom.