### PR TITLE
proposal for fixing missing javax.naming package

### DIFF
--- a/scripts/link_linux.sh
+++ b/scripts/link_linux.sh
@@ -11,7 +11,7 @@ JAVA_HOME="./jdks/linux/jdk-13"
 rm -rf dist/linux
 $REAL_JAVA_HOME/bin/jlink \
   --module-path $JAVA_HOME/jmods \
-  --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
+  --add-modules java.base,java.compiler,java.logging,java.naming,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/linux \
   --no-header-files \
   --no-man-pages \

--- a/scripts/link_mac.sh
+++ b/scripts/link_mac.sh
@@ -6,7 +6,7 @@ set -e
 # Build using jlink
 rm -rf dist/mac
 $JAVA_HOME/bin/jlink \
-  --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
+  --add-modules java.base,java.compiler,java.logging,java.naming,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/mac \
   --no-header-files \
   --no-man-pages \

--- a/scripts/link_windows.sh
+++ b/scripts/link_windows.sh
@@ -11,7 +11,7 @@ JAVA_HOME="./jdks/windows/jdk-13"
 rm -rf dist/windows
 $REAL_JAVA_HOME/bin/jlink \
   --module-path $JAVA_HOME/jmods \
-  --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
+  --add-modules java.base,java.compiler,java.logging,java.naming,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/windows \
   --no-header-files \
   --no-man-pages \


### PR DESCRIPTION
This is a proposal for fixing missing javax.naming package (#124) 

Including the `java.naming` module on `scripts/link_linux.sh` file fixis it on my local env.
