### PR TITLE
adding --system javac option to override the location of system modules

### DIFF
--- a/src/main/java/org/javacs/CompileBatch.java
+++ b/src/main/java/org/javacs/CompileBatch.java
@@ -113,6 +113,11 @@ class CompileBatch implements AutoCloseable {
     private static List<String> options(Set<Path> classPath, Set<String> addExports) {
         var list = new ArrayList<String>();
 
+        var javaHome = System.getenv("JAVA_HOME");
+        if (javaHome != null) {
+            Collections.addAll(list, "--system", javaHome);
+        }
+
         Collections.addAll(list, "-classpath", joinPath(classPath));
         Collections.addAll(list, "--add-modules", "ALL-MODULE-PATH");
         // Collections.addAll(list, "-verbose");


### PR DESCRIPTION
Specifies which JDK to use (by getting the system JDK though `JAVA_HOME` environment variable) when creating a Java Compiler in order to make the code intelligence capable on finding Java library classes that are not inside the `java-language-server` standalone copy of Java. (#124)