### PR TITLE
Remove --system javac option again

### DIFF
--- a/src/main/java/org/javacs/CompileBatch.java
+++ b/src/main/java/org/javacs/CompileBatch.java
@@ -113,11 +113,6 @@ class CompileBatch implements AutoCloseable {
     private static List<String> options(Set<Path> classPath, Set<String> addExports) {
         var list = new ArrayList<String>();
 
-        var javaHome = System.getenv("JAVA_HOME");
-        if (javaHome != null) {
-            Collections.addAll(list, "--system", javaHome);
-        }
-
         Collections.addAll(list, "-classpath", joinPath(classPath));
         Collections.addAll(list, "--add-modules", "ALL-MODULE-PATH");
         // Collections.addAll(list, "-verbose");


### PR DESCRIPTION
Removing the --system javac option introduced in #129, because it breaks the LSP server for Java version < 13 (#132).

The change in #130 didn't went through, as the state of master still includes the --system option that breaks the LSP.