### PR TITLE
145 Crashes on Arch Linux `NoSuchFileException: /usr/java`

### DIFF
--- a/src/main/java/org/javacs/JavaHomeHelper.java
+++ b/src/main/java/org/javacs/JavaHomeHelper.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -79,7 +80,9 @@ class JavaHomeHelper {
             List<Path> list;
             try {
                 list = Files.list(Paths.get(root)).collect(Collectors.toList());
-            } catch (IOException e) {
+            } catch(NoSuchFileException e) {
+				continue;
+			} catch (IOException e) {
                 throw new RuntimeException(e);
             }
             for (var jdk : list) {


### PR DESCRIPTION
JavaHomeHelper:81 throws `NoSuchFileException` in `Files.list` when the
directories listed on line 60 do not exist.  Given that we return
`NOT_FOUND` if nothing is found, it seems reasonable to simple swallow
the exception and allow `NOT_FOUND` if none of the directories exist.