### PR TITLE
Add title to Commands sent with completion items.

### DIFF
--- a/src/main/java/org/javacs/completion/CompletionProvider.java
+++ b/src/main/java/org/javacs/completion/CompletionProvider.java
@@ -627,6 +627,7 @@ public class CompletionProvider {
                 // Remove this if VSCode ever fixes https://github.com/microsoft/vscode/issues/78806
                 i.command = new Command();
                 i.command.command = "editor.action.triggerParameterHints";
+                i.command.title = "Trigger Parameter Hints";
             }
             i.insertTextFormat = 2; // Snippet
         }


### PR DESCRIPTION
The [language server protocol spec](https://microsoft.github.io/language-server-protocol/specification#command) says that titles with commands are mandatory. My language client ([LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim/)) barfs whenever it gets completion results without a title. Fixing this makes my client work.