### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/java/org/javacs/markup/ErrorProvider.java
+++ b/src/main/java/org/javacs/markup/ErrorProvider.java
@@ -38,7 +38,7 @@ public class ErrorProvider {
     private List<org.javacs.lsp.Diagnostic> compilerErrors(CompilationUnitTree root) {
         var result = new ArrayList<org.javacs.lsp.Diagnostic>();
         for (var d : task.diagnostics) {
-            if (!d.getSource().toUri().equals(root.getSourceFile().toUri())) continue;
+            if (d.getSource() == null || !d.getSource().toUri().equals(root.getSourceFile().toUri())) continue;
             if (d.getStartPosition() == -1 || d.getEndPosition() == -1) continue;
             result.add(lspDiagnostic(d, root.getLineMap()));
         }


### PR DESCRIPTION
I'm getting a NullPointerException when I add a jar to the classpath and it contains some imports to other classes not available in the classpath.

This PR fixes this issue.