### PR TITLE
Remove warning for '<error>' text, which is added during AST generation

### DIFF
--- a/src/main/java/org/javacs/markup/WarnUnused.java
+++ b/src/main/java/org/javacs/markup/WarnUnused.java
@@ -1,9 +1,17 @@
 package org.javacs.markup;
 
 import com.sun.source.tree.*;
-import com.sun.source.util.*;
-import java.util.*;
-import javax.lang.model.element.*;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 
 class WarnUnused extends TreeScanner<Void, Void> {
@@ -47,6 +55,8 @@ class WarnUnused extends TreeScanner<Void, Void> {
         unused.addAll(privateDeclarations.keySet());
         unused.addAll(localVariables.keySet());
         unused.removeAll(used);
+        // Remove if <error > field was injected while forming the AST
+        unused.removeIf(i -> i.toString().equals("<error>"));
         return unused;
     }
 

--- a/src/test/examples/missing-type-identifier/Sample.java
+++ b/src/test/examples/missing-type-identifier/Sample.java
@@ -1,0 +1,13 @@
+package com.sample;
+
+public class Sample {
+    public static void main(String[] args) {
+        // While forming the abstract syntax tree, the parser adds <error> after `arg`
+        // because it thinks `arg` is the type identifier, and there should be a variable
+        // name after it. This <error>, then, is not handled properly by the LS and causes
+        // LS to crash, as it wants to underline it as a not-used-variable, while it's
+        // non-existent in the original file.
+        for (arg : args) {
+        }
+    }
+};

--- a/src/test/java/org/javacs/JavaLanguageServerTest.java
+++ b/src/test/java/org/javacs/JavaLanguageServerTest.java
@@ -1,0 +1,33 @@
+package org.javacs;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.javacs.lsp.DidOpenTextDocumentParams;
+import org.javacs.lsp.TextDocumentItem;
+import org.junit.Test;
+
+public class JavaLanguageServerTest {
+
+    @Test
+    public void LintShouldNotCrashOnCodeWithMissingTypeIdentifier() {
+        String filePath = "src/test/examples/missing-type-identifier/Sample.java";
+        TextDocumentItem textDocument = new TextDocumentItem();
+        textDocument.uri = URI.create("file:///" + filePath);
+        try {
+            textDocument.text = Files.readString(Path.of(filePath));
+        } catch (IOException e) {
+            System.out.println(e.toString());
+        }
+        textDocument.version = 1;
+        textDocument.languageId = "java";
+        JavaLanguageServer server = LanguageServerFixture.getJavaLanguageServer();
+        server.didOpenTextDocument(new DidOpenTextDocumentParams(textDocument));
+
+        // Should not fail
+        server.lint(Collections.singleton(Paths.get(textDocument.uri)));
+    }
+}


### PR DESCRIPTION
Solves #173 