### PR TITLE
Allow bazel aquery failures for incorrect rule

### DIFF
--- a/src/main/java/org/javacs/InferConfig.java
+++ b/src/main/java/org/javacs/InferConfig.java
@@ -367,6 +367,7 @@ class InferConfig {
             "--output=proto",
             "--include_aspects", // required for java_proto_library, see
             // https://stackoverflow.com/questions/63430530/bazel-aquery-returns-no-action-information-for-java-proto-library
+            "--allow_analysis_failures",
             "mnemonic(" + filterMnemonic + ", " + kindUnion + ")"
         };
         var output = fork(bazelWorkspaceRoot, command);


### PR DESCRIPTION
The aquery command will fail if some rules fail. There are also customized rules set to always fail. This will allow the command finish. 