### PR TITLE
Auto-import completed classes

### DIFF
--- a/src/main/java/org/javacs/Extractors.java
+++ b/src/main/java/org/javacs/Extractors.java
@@ -1,0 +1,26 @@
+package org.javacs;
+
+import java.util.regex.Pattern;
+
+public class Extractors {
+
+    private static final Pattern PACKAGE_EXTRACTOR = Pattern.compile("^([a-z][_a-zA-Z0-9]*\\.)*[a-z][_a-zA-Z0-9]*");
+
+    public static String packageName(String className) {
+        var m = PACKAGE_EXTRACTOR.matcher(className);
+        if (m.find()) {
+            return m.group();
+        }
+        return "";
+    }
+
+    private static final Pattern SIMPLE_EXTRACTOR = Pattern.compile("[A-Z][_a-zA-Z0-9]*$");
+
+    public static String simpleName(String className) {
+        var m = SIMPLE_EXTRACTOR.matcher(className);
+        if (m.find()) {
+            return m.group();
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
Hello,

I first want to say I love this project so far. I discovered it today, and I think it will be very useful for me. 

I noticed that classes were not auto-importing on completion for me, and searching the issues I saw #167 that wasn't picked up. I thought I would give an implementation of this a try.

I have not added any tests for this yet, but I thought I would share the implementation first to see if you like the approach.


Original Commit Message:
-----------
This patch uses the CompilationUnitTree of the file being processed for a
completion to build a Set of imports for the current file and to get the path to
the file. It then uses the list of imports to determine whether the completion
candidate has already been imported. If not, the AddImport class is used to add
to the additionalTextEdits field on the CompletionItem.

Some small refactoring was done to pull useful class and package name extractors
out of JavaCompilerService.java.