### PR TITLE
Handle checked exception on the constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,23 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <argLine>
+                        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                        --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
             <!-- Set source 1.10 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,23 +58,6 @@
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <argLine>
-                        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-                        --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-                        --add-exports jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
-                        --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
-                        --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-                        --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-                        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-                        --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-                    </argLine>
-                </configuration>
-            </plugin>
             <!-- Set source 1.10 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/javacs/markup/WarnNotThrown.java
+++ b/src/main/java/org/javacs/markup/WarnNotThrown.java
@@ -3,6 +3,7 @@ package org.javacs.markup;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ThrowTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreePath;
@@ -73,6 +74,19 @@ class WarnNotThrown extends TreePathScanner<Void, Map<TreePath, String>> {
         var type = Trees.instance(task).getTypeMirror(path);
         addThrown(type);
         return super.visitThrow(t, notThrown);
+    }
+
+    @Override
+    public Void visitNewClass(NewClassTree t, Map<TreePath, String> notThrown) {
+        var trees = Trees.instance(task);
+        var target = trees.getElement(getCurrentPath());
+        if (target instanceof ExecutableElement) {
+            var method = (ExecutableElement) target;
+            for (var type : method.getThrownTypes()) {
+                addThrown(type);
+            }
+        }
+        return super.visitNewClass(t, notThrown);
     }
 
     @Override

--- a/src/test/examples/maven-project/src/org/javacs/warn/NotThrownConstructor.java
+++ b/src/test/examples/maven-project/src/org/javacs/warn/NotThrownConstructor.java
@@ -1,0 +1,15 @@
+package org.javacs.warn;
+
+import java.io.IOException;
+
+class NotThrownConstructor {
+    void isThrown() throws IOException {
+        new Inner();
+    }
+
+    private static class Inner {
+        private Inner() throws IOException {
+            throw new IOException();
+        }
+    }
+}

--- a/src/test/java/org/javacs/WarningsTest.java
+++ b/src/test/java/org/javacs/WarningsTest.java
@@ -120,6 +120,12 @@ public class WarningsTest {
         assertThat(errors, not(hasItem("unused_throws(8)")));
     }
 
+    @Test
+    public void notThrownConstructor() {
+        server.lint(List.of(FindResource.path("org/javacs/warn/NotThrownConstructor.java")));
+        assertThat(errors, empty());
+    }
+
     // TODO warn on type.equals(otherType)
     // TODO warn on map.get(wrongKeyType)
 }


### PR DESCRIPTION
WarnNotThrown didn't check the constructor invocations (visitNewClass).
This makes warnings even if it's legitimate.

In order to run a test, modules needed to be exported/opened as it's
using com.sun APIs. pom.xml is changed to specify this in `mvn test`.