### PR TITLE
Handle compiler.err.cant.resolve for imports

### DIFF
--- a/src/main/java/org/javacs/action/CodeActionProvider.java
+++ b/src/main/java/org/javacs/action/CodeActionProvider.java
@@ -164,6 +164,7 @@ public class CodeActionProvider {
                                 needsThrow.erasedParameterTypes,
                                 exceptionName);
                 return createQuickFix("Add 'throws'", addThrows);
+            case "compiler.err.cant.resolve":
             case "compiler.err.cant.resolve.location":
                 var simpleName = extractRange(task, d.range);
                 var allImports = new ArrayList<CodeAction>();

--- a/src/test/examples/maven-project/src/org/javacs/action/TestAddImportAnonymousClass.java
+++ b/src/test/examples/maven-project/src/org/javacs/action/TestAddImportAnonymousClass.java
@@ -1,0 +1,9 @@
+package org.javacs.action;
+
+class TestAddImportAnonymousClass {
+    void test() {
+        new Object() {
+            List<Integer> list;
+        };
+    }
+}

--- a/src/test/java/org/javacs/CodeActionTest.java
+++ b/src/test/java/org/javacs/CodeActionTest.java
@@ -62,6 +62,12 @@ public class CodeActionTest {
     }
 
     @Test
+    public void testAddImportInAnonymousClass() {
+        String[] expect = {"Import 'java.util.List'"};
+        assertThat(quickFix("org/javacs/action/TestAddImportAnonymousClass.java"), hasItems(expect));
+    }
+
+    @Test
     public void testRemoveNotThrown() {
         assertThat(quickFix("org/javacs/action/TestRemoveNotThrown.java"), contains("Remove 'IOException'"));
     }


### PR DESCRIPTION
It seems that unresolved idents inside anonymous classes are producing
"compiler.err.cant.resolve" errors instead of
"compiler.err.cant.resolve.location". Handle them in the same way.