### PR TITLE
Fix reading multibyte characters

### DIFF
--- a/src/main/java/org/javacs/debug/proto/DebugAdapter.java
+++ b/src/main/java/org/javacs/debug/proto/DebugAdapter.java
@@ -52,21 +52,11 @@ public class DebugAdapter {
 
     private static String readLength(InputStream client, int byteLength) {
         // Eat whitespace
-        // Have observed problems with extra \r\n sequences from VSCode
-        var next = read(client);
-        while (Character.isWhitespace(next)) {
-            next = read(client);
+        try {
+            return new String(client.readNBytes(byteLength), StandardCharsets.UTF_8).stripLeading();
+        } catch (IOException e) {
+            throw new RuntimeException("An error occurred during the reading of client data", e);
         }
-        // Append next
-        var result = new StringBuilder();
-        var i = 0;
-        while (true) {
-            result.append(next);
-            i++;
-            if (i == byteLength) break;
-            next = read(client);
-        }
-        return result.toString();
     }
 
     static String nextToken(InputStream client) {

--- a/src/main/java/org/javacs/lsp/LSP.java
+++ b/src/main/java/org/javacs/lsp/LSP.java
@@ -58,21 +58,11 @@ public class LSP {
 
     private static String readLength(InputStream client, int byteLength) {
         // Eat whitespace
-        // Have observed problems with extra \r\n sequences from VSCode
-        var next = read(client);
-        while (Character.isWhitespace(next)) {
-            next = read(client);
+        try {
+            return new String(client.readNBytes(byteLength), StandardCharsets.UTF_8).stripLeading();
+        } catch (IOException e) {
+            throw new RuntimeException("An error occurred during the reading of client data", e);
         }
-        // Append next
-        var result = new StringBuilder();
-        var i = 0;
-        while (true) {
-            result.append(next);
-            i++;
-            if (i == byteLength) break;
-            next = read(client);
-        }
-        return result.toString();
     }
 
     static String nextToken(InputStream client) {


### PR DESCRIPTION
Reading multibyte characters leads to corrupt FileStore and shows the wrong diagnostic.  Using the built-in method String#readNBytes helps to prevent it.