### PR TITLE
Allow docPath to be explicitly set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,16 @@ If the language server doesn't detect your external dependencies automatically, 
 }
 ```
 
-If all else fails, you can specify the java class path manually:
+If all else fails, you can specify the Java class path and the locations of
+source jars manually:
 
 ```json
 {
     "java.classPath": [
         "lib/some-dependency.jar"
+    ],
+    "java.docPath": [
+        "lib/some-dependency-sources.jar"
     ]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -66,6 +66,13 @@
                     },
                     "description": "Relative paths from workspace root to .jar files, .zip files, or folders that should be included in the Java class path"
                 },
+                "java.docPath": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Relative paths from workspace root to .jar files or .zip files containing source code, or to folders that should be included in the Java doc path"
+                },
                 "java.externalDependencies": {
                     "type": "array",
                     "items": {

--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -96,7 +96,7 @@ class JavaLanguageServer extends LanguageServer {
         // If classpath is specified by the user, don't infer anything
         if (!classPath.isEmpty()) {
             javaEndProgress();
-            return new JavaCompilerService(classPath, Collections.emptySet(), addExports);
+            return new JavaCompilerService(classPath, docPath(), addExports);
         }
         // Otherwise, combine inference with user-specified external dependencies
         else {
@@ -133,6 +133,15 @@ class JavaLanguageServer extends LanguageServer {
         return paths;
     }
 
+    private Set<Path> docPath() {
+        if (!settings.has("docPath")) return Set.of();
+        var array = settings.getAsJsonArray("docPath");
+        var paths = new HashSet<Path>();
+        for (var each : array) {
+            paths.add(Paths.get(each.getAsString()).toAbsolutePath());
+        }
+        return paths;
+    }
     private Set<String> addExports() {
         if (!settings.has("addExports")) return Set.of();
         var array = settings.getAsJsonArray("addExports");


### PR DESCRIPTION
I am writing Java code in an environment where the source is compiled using Makefiles and Ant.  I configure my editor to explicitly tell java-language-server the correct Java class path.  Unfortunately, there's currently no way to also explicitly set the doc path.  This change adds that capability.
