### PR TITLE
Install & Usage Improvements: Add single installation script and java-language-server entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ A Java [language server](https://github.com/Microsoft/vscode-languageserver-prot
 
 ## Installation (other editors)
 
-### Vim (with vim-lsc)
+### Base Install Steps
 
 - Checkout this repository
-- Run `./scripts/link_{linux|mac|windows}.sh`
-- Run `mvn package -DskipTests`
+- Run ./scripts/install.sh
+
+### Vim (with vim-lsc)
+
+- [Follow Base Install Steps](#base-install-steps)
 - Add the vim plugin [natebosch/vim-lsc](https://github.com/natebosch/vim-lsc) to your vimrc
 - Add vim-lsc configuration:
   ```vimrc
-  let g:lsc_server_commands = {'java': '<path-to-java-language-server>/java-language-server/dist/lang_server_{linux|mac|windows}.sh'}
+  let g:lsc_server_commands = {'java': '/usr/local/bin/java-language-server'}
   ```
 - See the [vim-lsc README](https://github.com/natebosch/vim-lsc/blob/master/README.md) for other configuration options.
 
@@ -24,9 +27,7 @@ Note: This tool is not compatible with [vim-lsp](https://github.com/prabirshrest
 
 ### KDE Kate
 
-- Checkout this repository
-- Run `./scripts/link_{linux|mac|windows}.sh`
-- Run `mvn package -DskipTests`
+- [Follow Base Install Steps](#base-install-steps)
 - Open your Kate editor
 - Go to Settings > Configure Kate... > LSP Client > User Server Settings
 - Add this lines to your User Server Settings:
@@ -36,7 +37,7 @@ Note: This tool is not compatible with [vim-lsp](https://github.com/prabirshrest
     {
         "java":
         {
-            "command": ["bash","<path-to-java-language-server>/java-language-server/dist/lang_server_{linux|mac|windows}.sh"],
+            "command": ["bash", "/usr/local/bin/java-language-server"],
             "url": "https://github.com/georgewfraser/java-language-server",
             "highlightingModeRegex": "^Java$"
         }
@@ -47,9 +48,7 @@ Note: This tool is not compatible with [vim-lsp](https://github.com/prabirshrest
 
 ### Sublime 3 (with LSP)
 
-- Checkout this repository
-- Run `./scripts/link_{linux|mac|windows}.sh`
-- Run `mvn package -DskipTests`
+- [Follow Base Install Steps](#base-install-steps)
 - Open your Sublime 3
 - Install Package Control (if missing)
 - Install the [LSP Package](https://packagecontrol.io/packages/LSP) (if missing)
@@ -62,7 +61,7 @@ Note: This tool is not compatible with [vim-lsp](https://github.com/prabirshrest
         "jls":
         {
             "enabled": true,
-            "command": ["bash", "<path-to-java-language-server>/java-language-server/dist/lang_server_{linux|mac|windows}.sh"],
+            "command": ["bash", "/usr/local/bin/java-language-server"],
             "scopes": ["source.java"],
             "syntaxes": ["Packages/Java/Java.sublime-syntax"],
             "languageId": "java"

--- a/dist/java-language-server
+++ b/dist/java-language-server
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+OS="unknown"
+if which -s uname;then
+  OS=$(uname |tr '[:upper:]' '[:lower:]')
+fi
+SCRIPTS_DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
+if [[ "${OS}" == 'darwin' ]]; then
+  ${SCRIPTS_DIR}/lang_server_mac.sh
+elif [[ "${OS}" == 'linux' ]]; then
+  ${SCRIPTS_DIR}/lang_server_linux.sh
+else
+  ${SCRIPTS_DIR}/lang_server_windows.sh
+fi

--- a/scripts/download_mac_jdk.sh
+++ b/scripts/download_mac_jdk.sh
@@ -3,11 +3,15 @@
 
 set -e
 
-# Download mac jdk
+# Download mac jdk if it doesn't exist
+if [[ -x jdks/mac/jdk-18/Contents/Home/bin/java ]];then
+  exit 0
+fi
+
 mkdir -p jdks/mac
 cd jdks/mac
 curl https://download.java.net/java/GA/jdk18.0.1.1/65ae32619e2f40f3a9af3af1851d6e19/2/GPL/openjdk-18.0.1.1_macos-x64_bin.tar.gz > mac.tar.gz
 gunzip -c mac.tar.gz | tar xopf -
 rm mac.tar.gz
-mv jdk-18.0.1.1.jdk jdk-18
+ln -s jdk-18.0.1.1.jdk jdk-18
 cd ../..

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+INSTALL_DIR=${INSTALL_DIR:="/usr/local/java-language-server"}
+INSTALL_BIN=${INSTALL_BIN:="/usr/local/bin"}
+OS="unknown"
+if which -s uname;then
+  OS=$(uname |tr '[:upper:]' '[:lower:]')
+fi
+
+uninstall() {
+  if echo ${INSTALL_DIR}|grep -q "/usr/local" || echo ${INSTALL_BIN}|grep -q "/usr/local";then
+    local sudoprompt="SUDO password required to remove language server from INSTALL_DIR=${INSTALL_DIR} and INSTALL_BIN=${INSTALL_BIN}: "
+    sudo -p "${sudoprompt}" rm -rf ${INSTALL_DIR} ${INSTALL_BIN}/java-language-server
+  else
+    rm -rf ${INSTALL_DIR} ${INSTALL_BIN}/java-language-server
+  fi
+}
+
+install() {
+  if ! echo "${OS}" |grep -Eq '(darwin|linux)';then
+    echo "Windows/Uknown OS easy install not implemented yet please manually install"
+    exit 1
+  fi
+
+  if echo ${INSTALL_DIR}|grep -q "/usr/local" || echo ${INSTALL_BIN}|grep -q "/usr/local";then
+    local sudoprompt="SUDO password required to install language server to INSTALL_DIR=${INSTALL_DIR} and INSTALL_BIN=${INSTALL_BIN}: "
+
+    sudo -p "${sudoprompt}" -v
+    uninstall
+    sudo -p "${sudoprompt}" cp -r dist ${INSTALL_DIR}
+    sudo -p "${sudoprompt}" ln -s "${INSTALL_DIR}/java-language-server" "${INSTALL_BIN}/java-language-server"
+
+  else
+    uninstall
+    cp -r dist ${INSTALL_DIR}
+    ln -s "${INSTALL_DIR}/java-language-server" "${INSTALL_BIN}/java-language-server"
+  fi
+}
+
+build() {
+  if [[ "${OS}" == 'darwin' ]]; then
+    ./scripts/download_mac_jdk.sh
+    ./scripts/link_mac.sh
+  elif [[ "${OS}" == 'linux' ]]; then
+    ./scripts/download_linux_jdk.sh
+    ./scripts/link_linux.sh
+  else # hopefully windows
+    ./scripts/download_windows_jdk.sh
+    ./scripts/link_windows.sh
+  fi
+}
+
+case "$1" in
+  build)
+    build
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  install)
+    build
+    install
+    ;;
+  help)
+    echo "Usage: $0 { install(default) | build | uninstall }"
+    echo "defaults to install"
+    exit 1
+    ;;
+  *)
+    echo -n "Do you want to install? Y/N: " && read -r
+    r=$(echo "${REPLY}" |tr '[:upper:]' '[:lower:]')
+    if [[ "${r}" == "y" ]];then
+      build
+      install
+    else
+      echo "Install cancelled..."
+      exit 1
+    fi
+    ;;
+esac

--- a/scripts/link_linux.sh
+++ b/scripts/link_linux.sh
@@ -8,10 +8,12 @@ JAVA_HOME="./jdks/linux/jdk-18"
 
 # Build in dist/linux
 rm -rf dist/linux
-jlink \
-  --module-path $JAVA_HOME/jmods \
+${JAVA_HOME}/jlink \
+  --module-path ${JAVA_HOME}/jmods \
   --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/linux \
   --no-header-files \
   --no-man-pages \
   --compress 2
+
+mvn package -DskipTests

--- a/scripts/link_mac.sh
+++ b/scripts/link_mac.sh
@@ -4,14 +4,16 @@
 set -e
 
 # Set env variables to build with mac toolchain but linux target
-JAVA_HOME="./jdks/mac/jdk-18"
+JAVA_HOME="./jdks/mac/jdk-18/Contents/Home"
 
 # Build using jlink
 rm -rf dist/mac
-jlink \
-  --module-path $JAVA_HOME/Contents/Home/jmods \
+${JAVA_HOME}/bin/jlink \
+  --module-path ${JAVA_HOME}/jmods \
   --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/mac \
   --no-header-files \
   --no-man-pages \
   --compress 2
+
+mvn package -DskipTests


### PR DESCRIPTION
I ran into some issues w/ the existing installation scripts on mac so i thought i'd share my fixes and i also took the time to add a unified installation script and a standardized runtime script so that there is minimal configuration between OS'es if you switch frequently between linux / mac / etc.

I don't use windows so not sure how much of this will work there.