### PR TITLE
Fix compiler warnings output when compiling with Bazel.

### DIFF
--- a/src/main/java/org/javacs/FileStore.java
+++ b/src/main/java/org/javacs/FileStore.java
@@ -257,8 +257,10 @@ public class FileStore {
 
     static InputStream inputStream(Path file) {
         var uri = file.toUri();
-        if (activeDocuments.containsKey(uri)) {
-            var string = activeDocuments.get(uri).content;
+        file = Paths.get(uri);
+
+        if (activeDocuments.containsKey(file)) {
+            var string = activeDocuments.get(file).content;
             var bytes = string.getBytes();
             return new ByteArrayInputStream(bytes);
         }
@@ -275,8 +277,10 @@ public class FileStore {
 
     static BufferedReader bufferedReader(Path file) {
         var uri = file.toUri();
-        if (activeDocuments.containsKey(uri)) {
-            var string = activeDocuments.get(uri).content;
+        file = Paths.get(uri);
+
+        if (activeDocuments.containsKey(file)) {
+            var string = activeDocuments.get(file).content;
             return new BufferedReader(new StringReader(string));
         }
         try {

--- a/src/main/java/org/javacs/Parser.java
+++ b/src/main/java/org/javacs/Parser.java
@@ -303,7 +303,8 @@ class Parser {
                 }
                 if (last == -1) {
                     throw new RuntimeException(
-                            String.format("No cursor in %s is between %d and %d", offsets, start, end));
+                            String.format(
+                                    "No cursor in %s is between %d and %d", Arrays.toString(offsets), start, end));
                 }
                 return last;
             }


### PR DESCRIPTION
The activeDocuments map in FileStore maps Path to content, but in a couple of places the code calls activeDocuments.get() with URIs instead of Paths.

The code looks wrong but I do not know whether the change I made is correct.
