### PR TITLE
Remove class from Javac on delete/rename file

### DIFF
--- a/lib/extension.ts
+++ b/lib/extension.ts
@@ -26,14 +26,6 @@ export async function activate(context: ExtensionContext) {
             // Synchronize the setting section 'java' to the server
             // NOTE: this currently doesn't do anything
             configurationSection: 'java',
-            // Notify the server about file changes to 'javaconfig.json' files contain in the workspace
-            fileEvents: [
-                workspace.createFileSystemWatcher('**/javaconfig.json'),
-                workspace.createFileSystemWatcher('**/pom.xml'),
-                workspace.createFileSystemWatcher('**/WORKSPACE'),
-                workspace.createFileSystemWatcher('**/BUILD'),
-                workspace.createFileSystemWatcher('**/*.java')
-            ]
         },
         outputChannelName: 'Java',
         revealOutputChannelOn: 4 // never

--- a/src/main/java/org/javacs/JavaCompilerService.java
+++ b/src/main/java/org/javacs/JavaCompilerService.java
@@ -65,7 +65,7 @@ class JavaCompilerService implements CompilerProvider {
             cachedCompile.borrow.close();
         }
         cachedCompile = doCompile(sources);
-        cachedModified.clear();
+        clearCachedModified();
         for (var f : sources) {
             cachedModified.put(f, f.getLastModified());
         }
@@ -348,6 +348,10 @@ class JavaCompilerService implements CompilerProvider {
     public CompileTask compile(Collection<? extends JavaFileObject> sources) {
         var compile = compileBatch(sources);
         return new CompileTask(compile.task, compile.roots, diags, compile::close);
+    }
+
+    void clearCachedModified() {
+        cachedModified.clear();
     }
 
     private static final Logger LOG = Logger.getLogger("main");

--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -4,6 +4,7 @@ import static org.javacs.JsonHelper.GSON;
 
 import com.google.gson.*;
 import com.sun.source.util.Trees;
+import com.sun.tools.javac.tree.JCTree;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -142,6 +143,7 @@ class JavaLanguageServer extends LanguageServer {
         }
         return paths;
     }
+
     private Set<String> addExports() {
         if (!settings.has("addExports")) return Set.of();
         var array = settings.getAsJsonArray("addExports");
@@ -189,7 +191,7 @@ class JavaLanguageServer extends LanguageServer {
     }
 
     private static final String[] watchFiles = {
-        "**/*.java", "**/pom.xml", "**/BUILD",
+        "**/*.java", "**/pom.xml", "**/BUILD", "**/javaconfig.json", "**/WORKSPACE"
     };
 
     @Override
@@ -241,10 +243,10 @@ class JavaLanguageServer extends LanguageServer {
                         FileStore.externalChange(file);
                         break;
                     case FileChangeType.Deleted:
-                        FileStore.externalDelete(file);
+                        removeClass(file);
                         break;
                 }
-                return;
+                continue;
             }
             var name = file.getFileName().toString();
             switch (name) {
@@ -478,6 +480,24 @@ class JavaLanguageServer extends LanguageServer {
         var file = Paths.get(path.getCompilationUnit().getSourceFile().toUri());
         var position = trees.getSourcePositions().getStartPosition(path.getCompilationUnit(), path.getLeaf());
         return new RenameVariable(file, (int) position, newName);
+    }
+
+    private void removeClass(Path file) {
+        var className = cacheCompiler.fileManager.getClassName(file);
+        FileStore.externalDelete(file);
+        var compiler = compiler();
+        var referencePaths =
+                Arrays.stream(compiler.findTypeReferences(className)).filter(ref -> !ref.equals(file)).toList();
+        if (referencePaths.isEmpty()) {
+            return;
+        }
+        for (var referencePath : referencePaths) {
+            try (var task = compiler.compile(referencePath)) {
+                compiler.compiler.removeClass((JCTree.JCCompilationUnit) task.root(), className);
+            }
+        }
+        compiler.clearCachedModified();
+        lint(referencePaths);
     }
 
     private boolean uncheckedChanges = false;

--- a/src/main/java/org/javacs/SourceFileManager.java
+++ b/src/main/java/org/javacs/SourceFileManager.java
@@ -42,13 +42,17 @@ class SourceFileManager extends ForwardingJavaFileManager<StandardJavaFileManage
     public String inferBinaryName(Location location, JavaFileObject file) {
         if (location == StandardLocation.SOURCE_PATH) {
             var source = (SourceFileObject) file;
-            var packageName = FileStore.packageName(source.path);
-            var className = removeExtension(source.path.getFileName().toString());
-            if (!packageName.isEmpty()) className = packageName + "." + className;
-            return className;
+            return getClassName(source.path);
         } else {
             return super.inferBinaryName(location, file);
         }
+    }
+
+    String getClassName(Path path) {
+        var packageName = FileStore.packageName(path);
+        var className = removeExtension(path.getFileName().toString());
+        if (!packageName.isEmpty()) className = packageName + "." + className;
+        return className;
     }
 
     private String removeExtension(String fileName) {

--- a/src/main/java/org/javacs/lsp/LSP.java
+++ b/src/main/java/org/javacs/lsp/LSP.java
@@ -6,6 +6,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -150,11 +151,20 @@ public class LSP {
         @Override
         public void registerCapability(String method, JsonElement options) {
             var params = new RegistrationParams();
-            params.id = UUID.randomUUID().toString();
-            params.method = method;
-            params.registerOptions = options;
-
-            notifyClient(send, "client/registerCapability", params);
+            var registration = new RegistrationParams.Registration();
+            registration.id = UUID.randomUUID().toString();
+            registration.method = method;
+            registration.registerOptions = options;
+            params.registrations.add(registration);
+            var jsonText = toJson(params);
+            var requestMethod = "client/registerCapability";
+            // The request should contain the id param. Otherwise, it will be considered a notification.
+            var id = new Random().nextInt();
+            var messageText =
+                    String.format(
+                            "{\"jsonrpc\":\"2.0\",\"id\":\"%d\",\"method\":\"%s\",\"params\":%s}",
+                            id, requestMethod, jsonText);
+            writeClient(send, messageText);
         }
 
         @Override
@@ -172,7 +182,7 @@ public class LSP {
         // Read messages and process cancellations on a separate thread
         class MessageReader implements Runnable {
             void peek(Message message) {
-                if (message.method.equals("$/cancelRequest")) {
+                if ("$/cancelRequest".equals(message.method)) {
                     var params = gson.fromJson(message.params, CancelParams.class);
                     var removed = pending.removeIf(r -> r.id != null && r.id.equals(params.id));
                     if (removed) LOG.info(String.format("Cancelled request %d, which had not yet started", params.id));

--- a/src/main/java/org/javacs/lsp/RegistrationParams.java
+++ b/src/main/java/org/javacs/lsp/RegistrationParams.java
@@ -1,8 +1,14 @@
 package org.javacs.lsp;
 
 import com.google.gson.JsonElement;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RegistrationParams {
-    public String id, method;
-    public JsonElement registerOptions;
+    List<Registration> registrations = new ArrayList<>();
+
+    public static class Registration {
+        public String id, method;
+        public JsonElement registerOptions;
+    }
 }


### PR DESCRIPTION
- Removing class from Javac on delete file event by calling inner methods `syms.removeClass(...)` and `chk.removeCompiled(...)`
- All references on deleted class are linting after being removed
- Fixed the dynamic registration for capabilities.