### PR TITLE
fix: Adjust shebang to point to `/usr/bin/env bash`

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Compile the benchmark
 mvn test-compile

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/download_linux_jdk.sh
+++ b/scripts/download_linux_jdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Download a copy of linux JDK in jdks/linux
 
 set -e

--- a/scripts/download_mac_jdk.sh
+++ b/scripts/download_mac_jdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Download a copy of mac JDK in jdks/mac
 
 set -e

--- a/scripts/download_windows_jdk.sh
+++ b/scripts/download_windows_jdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Download a copy of windows JDK in jdks/windows
 
 set -e

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Grab root directory to help with creating an absolute path for changed files.
 root_dir="$(git rev-parse --show-toplevel)"

--- a/scripts/gen_proto.sh
+++ b/scripts/gen_proto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 protoc -I=src/main/protobuf --java_out=src/main/java src/main/protobuf/build.proto
 protoc -I=src/main/protobuf --java_out=src/main/java src/main/protobuf/analysis.proto
 protoc -I=src/main/protobuf --java_out=src/main/java src/main/protobuf/analysis_v2.proto

--- a/scripts/link_linux.sh
+++ b/scripts/link_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create self-contained copy of java in dist/linux
 
 set -e

--- a/scripts/link_mac.sh
+++ b/scripts/link_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create self-contained copy of java in dist/mac
 
 set -e

--- a/scripts/link_windows.sh
+++ b/scripts/link_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create self-contained copy of java in dist/windows
 
 set -e


### PR DESCRIPTION
It's recommended to point the shebang for bash scripts to `/usr/bin/env bash` instead of `/bin/bash` to account for systems that may have a non-standard binary layout, like, e.g., NixOS. This patch adjust the install scripts to properly handle these cases.