### PR TITLE
Remove deprecated rangeLength

### DIFF
--- a/src/main/java/org/javacs/FileStore.java
+++ b/src/main/java/org/javacs/FileStore.java
@@ -330,7 +330,17 @@ public class FileStore {
             writer.write(change.text);
 
             // Skip replaced text
-            reader.skip(change.rangeLength);
+            if (change.range.start.line == change.range.end.line) {
+                int chars = change.range.end.character - change.range.start.character;
+                reader.skip(chars);
+            } else {
+                int lines = change.range.end.line - change.range.start.line;
+                int chars = change.range.end.character;
+                for (int lineSkip = 0; lineSkip < lines; lineSkip++) {
+                    reader.readLine();                    
+                }
+                reader.skip(chars);
+            }
 
             // Write remaining text
             while (true) {

--- a/src/main/java/org/javacs/lsp/TextDocumentContentChangeEvent.java
+++ b/src/main/java/org/javacs/lsp/TextDocumentContentChangeEvent.java
@@ -2,6 +2,5 @@ package org.javacs.lsp;
 
 public class TextDocumentContentChangeEvent {
     public Range range;
-    public Integer rangeLength;
     public String text;
 }


### PR DESCRIPTION
rangeLength has been deprecated inside TextDocumentChangeEvent. Helix doesn't provide it anymore, leading the LSP to crash when using it.

This should also fix #84 