### PR TITLE
Fix language server crash when it encounters a file that is not UTF-8

### DIFF
--- a/src/main/java/org/javacs/FileStore.java
+++ b/src/main/java/org/javacs/FileStore.java
@@ -2,6 +2,7 @@ package org.javacs;
 
 import java.io.*;
 import java.net.URI;
+import java.nio.charset.CharacterCodingException;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
 import java.time.Instant;
@@ -196,7 +197,7 @@ public class FileStore {
             var time = Files.getLastModifiedTime(file).toInstant();
             var packageName = StringSearch.packageName(file);
             javaSources.put(file, new Info(time, packageName));
-        } catch (NoSuchFileException e) {
+        } catch (NoSuchFileException | CharacterCodingException e) {
             LOG.warning(e.getMessage());
             javaSources.remove(file);
         } catch (IOException e) {

--- a/src/main/java/org/javacs/FileStore.java
+++ b/src/main/java/org/javacs/FileStore.java
@@ -89,6 +89,12 @@ public class FileStore {
         return javaSources.keySet();
     }
 
+    static void reset() {
+        activeDocuments.clear();
+        workspaceRoots.clear();
+        javaSources.clear();
+    }
+
     static List<Path> list(String packageName) {
         var list = new ArrayList<Path>();
         for (var file : javaSources.keySet()) {

--- a/src/main/java/org/javacs/StringSearch.java
+++ b/src/main/java/org/javacs/StringSearch.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.CharacterCodingException;
 import java.nio.file.*;
 import java.util.*;
 import java.util.logging.Logger;
@@ -369,7 +370,7 @@ public class StringSearch {
         return parts[parts.length - 1];
     }
 
-    static String packageName(Path file) {
+    static String packageName(Path file) throws CharacterCodingException {
         var packagePattern = Pattern.compile("^package +(.*);");
         var startOfClass = Pattern.compile("^[\\w ]*class +\\w+");
         try (var lines = FileStore.lines(file)) {
@@ -381,6 +382,8 @@ public class StringSearch {
                     return id;
                 }
             }
+        } catch (CharacterCodingException e) {
+            throw e;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/examples/encoding/EncodingWindows1252.java
+++ b/src/test/examples/encoding/EncodingWindows1252.java
@@ -1,0 +1,14 @@
+package org.javacs.example;
+
+// This file is intentionally not Unicode. It exists to test handling
+// non-unicode files.
+//
+// This file should be encoded using the Windows-1252 encoding
+
+class EncodingWindows1252 {
+	/**
+	 * This property tests for the support of non-unicode strings such as "ü".
+	 * Also this comment tests for support in doc comments.
+	 */
+	String uWithUmlaut = "ü";
+}

--- a/src/test/java/org/javacs/FileEncodingTest.java
+++ b/src/test/java/org/javacs/FileEncodingTest.java
@@ -1,0 +1,30 @@
+package org.javacs;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Paths;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * These tests are isolated because bugs caused by encoding issues could cause
+ * phantom failures in other tests.
+ */
+public class FileEncodingTest {
+
+    @Test
+    public void packageNameForNonUnicodeSource() {
+        var encodingTestRoot = Paths.get("src/test/examples/encoding").normalize();
+
+        // If an exception is thrown due to an unknown encoding it would
+        // be here.
+        FileStore.setWorkspaceRoots(Set.of(encodingTestRoot));
+
+        var file = FindResource.path("/org/javacs/example/EncodingWindows1252.java");
+
+        // Currently, non-unicode files are ignored. This test will change if
+        // support is added in the future.
+        assertThat(FileStore.suggestedPackageName(file), equalTo(""));
+    }
+}

--- a/src/test/java/org/javacs/FileEncodingTest.java
+++ b/src/test/java/org/javacs/FileEncodingTest.java
@@ -6,12 +6,18 @@ import static org.junit.Assert.assertThat;
 import java.nio.file.Paths;
 import java.util.Set;
 import org.junit.Test;
+import org.junit.Before;
 
 /**
  * These tests are isolated because bugs caused by encoding issues could cause
  * phantom failures in other tests.
  */
 public class FileEncodingTest {
+
+    @Before
+    public void resetSourcesBefore() {
+        FileStore.reset();
+    }
 
     @Test
     public void packageNameForNonUnicodeSource() {

--- a/src/test/java/org/javacs/LanguageServerFixture.java
+++ b/src/test/java/org/javacs/LanguageServerFixture.java
@@ -49,6 +49,8 @@ public class LanguageServerFixture {
     }
 
     static JavaLanguageServer getJavaLanguageServer(Path workspaceRoot, LanguageClient client) {
+        FileStore.reset();
+
         var server = new JavaLanguageServer(client);
         var init = new InitializeParams();
 


### PR DESCRIPTION
This PR fixes the crash by ignoring any file that throws an encoding exception while its being read.