### PR TITLE
Enforce explicit plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,59 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>require-all-plugin-versions-to-be-set</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requirePluginVersions />
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Compile-time configuration -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hi!

I recently bumped the Maven version in Nixpgks (https://github.com/NixOS/nixpkgs/pull/238746) and ran into some small but annoying manual effort w.r.t. the this package. The issue is that this package is packaged using the [double invocation](https://ryantm.github.io/nixpkgs/languages-frameworks/maven/#double-invocation) method which unfortunately breaks if not all maven plugin versions are set explicitly.

We're extending the documentation to prevent this (https://github.com/NixOS/nixpkgs/pull/238774), but I'm reaching out to fix the packages which have already been packaged. In this PR, we explicitly set the versions of a few plugins which hadn't had their versions set explicitly before and add a check with the enforcer plugin to make sure this won't accidentally break in the future.

Note that the exact versions of the plugins that you're using are not important to us and please do change them as you see fit. We only ask that you explicitly set the versions of all plugins so that downstream upgrades can run automatically.

Thank you.

(This was copy-pasta as I have a few repositories to go through. Please just ask if anything is unclear.)