### PR TITLE
Cleanup javac on remove/rename java class

### DIFF
--- a/src/main/java/org/javacs/JavaCompilerService.java
+++ b/src/main/java/org/javacs/JavaCompilerService.java
@@ -65,7 +65,7 @@ class JavaCompilerService implements CompilerProvider {
             cachedCompile.borrow.close();
         }
         cachedCompile = doCompile(sources);
-        cachedModified.clear();
+        clearCachedModified();
         for (var f : sources) {
             cachedModified.put(f, f.getLastModified());
         }
@@ -348,6 +348,10 @@ class JavaCompilerService implements CompilerProvider {
     public CompileTask compile(Collection<? extends JavaFileObject> sources) {
         var compile = compileBatch(sources);
         return new CompileTask(compile.task, compile.roots, diags, compile::close);
+    }
+
+    void clearCachedModified() {
+        cachedModified.clear();
     }
 
     private static final Logger LOG = Logger.getLogger("main");

--- a/src/main/java/org/javacs/SourceFileManager.java
+++ b/src/main/java/org/javacs/SourceFileManager.java
@@ -42,13 +42,17 @@ class SourceFileManager extends ForwardingJavaFileManager<StandardJavaFileManage
     public String inferBinaryName(Location location, JavaFileObject file) {
         if (location == StandardLocation.SOURCE_PATH) {
             var source = (SourceFileObject) file;
-            var packageName = FileStore.packageName(source.path);
-            var className = removeExtension(source.path.getFileName().toString());
-            if (!packageName.isEmpty()) className = packageName + "." + className;
-            return className;
+            return getClassName(source.path);
         } else {
             return super.inferBinaryName(location, file);
         }
+    }
+
+    String getClassName(Path path) {
+        var packageName = FileStore.packageName(path);
+        var className = removeExtension(path.getFileName().toString());
+        if (!packageName.isEmpty()) className = packageName + "." + className;
+        return className;
     }
 
     private String removeExtension(String fileName) {


### PR DESCRIPTION
- Removing class from Javac on delete file event by calling inner methods syms.removeClass(...) and chk.removeCompiled(...)
- All references on deleted class are linting after being removed