### PR TITLE
Add compiler extra args configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,13 @@
                     },
                     "description": "Relative paths from workspace root to .jar files, .zip files, or folders that should be included in the Java class path"
                 },
+                "java.extraCompilerArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Extra compiler args, for example [\"--enable-preview\",\"-source 21\"]."
+                },
                 "java.docPath": {
                     "type": "array",
                     "items": {

--- a/src/main/java/org/javacs/CompileBatch.java
+++ b/src/main/java/org/javacs/CompileBatch.java
@@ -101,7 +101,7 @@ class CompileBatch implements AutoCloseable {
     private static ReusableCompiler.Borrow batchTask(
             JavaCompilerService parent, Collection<? extends JavaFileObject> sources) {
         parent.diags.clear();
-        var options = options(parent.classPath, parent.addExports);
+        var options = options(parent.classPath, parent.addExports,parent.extraArgs);
         return parent.compiler.getTask(parent.fileManager, parent.diags::add, options, List.of(), sources);
     }
 
@@ -110,7 +110,7 @@ class CompileBatch implements AutoCloseable {
         return classOrSourcePath.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
     }
 
-    private static List<String> options(Set<Path> classPath, Set<String> addExports) {
+    private static List<String> options(Set<Path> classPath, Set<String> addExports,Set<String> extraArgs) {
         var list = new ArrayList<String>();
 
         Collections.addAll(list, "-classpath", joinPath(classPath));
@@ -131,6 +131,7 @@ class CompileBatch implements AutoCloseable {
                 "-Xlint:unchecked",
                 "-Xlint:varargs",
                 "-Xlint:static");
+        list.addAll(extraArgs);
         for (var export : addExports) {
             list.add("--add-exports");
             list.add(export + "=ALL-UNNAMED");

--- a/src/main/java/org/javacs/JavaCompilerService.java
+++ b/src/main/java/org/javacs/JavaCompilerService.java
@@ -12,6 +12,7 @@ class JavaCompilerService implements CompilerProvider {
     // Not modifiable! If you want to edit these, you need to create a new instance
     final Set<Path> classPath, docPath;
     final Set<String> addExports;
+    final Set<String> extraArgs;
     final ReusableCompiler compiler = new ReusableCompiler();
     final Docs docs;
     final Set<String> jdkClasses = ScanClassPath.jdkTopLevelClasses(), classPathClasses;
@@ -21,7 +22,7 @@ class JavaCompilerService implements CompilerProvider {
     // TODO intercept files that aren't in the batch and erase method bodies so compilation is faster
     final SourceFileManager fileManager;
 
-    JavaCompilerService(Set<Path> classPath, Set<Path> docPath, Set<String> addExports) {
+    JavaCompilerService(Set<Path> classPath, Set<Path> docPath, Set<String> addExports, Set<String> extraArgs) {
         System.err.println("Class path:");
         for (var p : classPath) {
             System.err.println("  " + p);
@@ -34,6 +35,7 @@ class JavaCompilerService implements CompilerProvider {
         this.classPath = Collections.unmodifiableSet(classPath);
         this.docPath = Collections.unmodifiableSet(docPath);
         this.addExports = Collections.unmodifiableSet(addExports);
+        this.extraArgs = Collections.unmodifiableSet(extraArgs);
         this.docs = new Docs(docPath);
         this.classPathClasses = ScanClassPath.classPathTopLevelClasses(classPath);
         this.fileManager = new SourceFileManager();

--- a/src/main/java/org/javacs/JavaLanguageServer.java
+++ b/src/main/java/org/javacs/JavaLanguageServer.java
@@ -92,11 +92,12 @@ class JavaLanguageServer extends LanguageServer {
 
         var externalDependencies = externalDependencies();
         var classPath = classPath();
+        var extraArgs = extraCompilerArgs();
         var addExports = addExports();
         // If classpath is specified by the user, don't infer anything
         if (!classPath.isEmpty()) {
             javaEndProgress();
-            return new JavaCompilerService(classPath, docPath(), addExports);
+            return new JavaCompilerService(classPath, docPath(), addExports, extraArgs);
         }
         // Otherwise, combine inference with user-specified external dependencies
         else {
@@ -109,7 +110,7 @@ class JavaLanguageServer extends LanguageServer {
             var docPath = infer.buildDocPath();
 
             javaEndProgress();
-            return new JavaCompilerService(classPath, docPath, addExports);
+            return new JavaCompilerService(classPath, docPath, addExports, extraArgs);
         }
     }
 
@@ -131,6 +132,17 @@ class JavaLanguageServer extends LanguageServer {
             paths.add(Paths.get(each.getAsString()).toAbsolutePath());
         }
         return paths;
+    }
+
+    private Set<String> extraCompilerArgs(){
+        if (!settings.has("extraCompilerArgs")) return Set.of();
+        var array = settings.getAsJsonArray("extraCompilerArgs");
+        var args = new HashSet<String>();
+        for (var each : array) {
+            // split "a b  c" to ["a","b","c"]
+            args.addAll(Arrays.asList(each.getAsString().split("\\s+")));
+        }
+        return args;
     }
 
     private Set<Path> docPath() {


### PR DESCRIPTION
Hello, 
I like your project very much. 
Recently I switched to vscode to develop my JDK 22 -based program. I found that this project use the Java Compiler API , which support the unpublished JDK (like 22). 

I added the `extraCompilerArgs` option to allow pass ` -enable-preview` and `-source 22` when compiling.