### PR TITLE
Use latest textmate grammar from redhat-developer/vscode-java

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: Release
 
 on:
   push:
-    tags:
-      - release
+    branches:
+      - master
+  pull_request:
+    branches: 
+      - master
 
 jobs:
   build:
@@ -35,5 +38,8 @@ jobs:
       run: mvn --batch-mode package
     - name: Build extension
       run: npm run-script vscode:build
-    - name: Publish extension in VSCode marketplace
-      run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath build.vsix
+    - name: Upload VSIX
+      uses: actions/upload-artifact@v4
+      with:
+        name: vsix
+        path: build.vsix

--- a/lib/java.tmLanguage.json
+++ b/lib/java.tmLanguage.json
@@ -1,492 +1,1888 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ealap/tmlanguage/master/tmlanguage.json",
+	"information_for_contributors": [
+		"This file has been copied from https://github.com/redhat-developer/vscode-java/blob/master/language-support/java/java.tmLanguage.json",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/redhat-developer/vscode-java/commit/f09b712f5d6d6339e765f58c8dfab3f78a378183",
 	"name": "Java",
 	"scopeName": "source.java",
 	"patterns": [
 		{
-			"include": "#class-declaration"
+			"begin": "\\b(package)\\b\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.package.java"
+				}
+			},
+			"end": "\\s*(;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.java"
+				}
+			},
+			"name": "meta.package.java",
+			"contentName": "storage.modifier.package.java",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"match": "(?<=\\.)\\s*\\.|\\.(?=\\s*;)",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?<!_)_(?=\\s*(\\.|;))|\\b\\d+|-+",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "[A-Z]+",
+					"name": "invalid.deprecated.package_name_not_lowercase.java"
+				},
+				{
+					"match": "(?x)\\b(?<!\\$)\n(abstract|assert|boolean|break|byte|case|catch|char|class|\nconst|continue|default|do|double|else|enum|extends|final|\nfinally|float|for|goto|if|implements|import|instanceof|int|\ninterface|long|native|new|non-sealed|package|permits|private|protected|public|\nreturn|sealed|short|static|strictfp|super|switch|syncronized|this|\nthrow|throws|transient|try|void|volatile|while|yield|\ntrue|false|null)\\b",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.java"
+				}
+			]
 		},
 		{
-			"include": "#annotations"
+			"begin": "\\b(import)\\b\\s*\\b(static)?\\b\\s",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.import.java"
+				},
+				"2": {
+					"name": "storage.modifier.java"
+				}
+			},
+			"end": "\\s*(;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.java"
+				}
+			},
+			"name": "meta.import.java",
+			"contentName": "storage.modifier.import.java",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"match": "(?<=\\.)\\s*\\.|\\.(?=\\s*;)",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?<!\\.)\\s*\\*",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?<!_)_(?=\\s*(\\.|;))|\\b\\d+|-+",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "(?x)\\b(?<!\\$)\n(abstract|assert|boolean|break|byte|case|catch|char|class|\nconst|continue|default|do|double|else|enum|extends|final|\nfinally|float|for|goto|if|implements|import|instanceof|int|\ninterface|long|native|new|non-sealed|package|permits|private|protected|public|\nreturn|sealed|short|static|strictfp|super|switch|syncronized|this|\nthrow|throws|transient|try|void|volatile|while|yield|\ntrue|false|null)\\b",
+					"name": "invalid.illegal.character_not_allowed_here.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.java"
+				},
+				{
+					"match": "\\*",
+					"name": "variable.language.wildcard.java"
+				}
+			]
 		},
 		{
-			"include": "#keywords"
+			"include": "#comments-javadoc"
 		},
 		{
-			"include": "#comments"
+			"include": "#code"
+		},
+		{
+			"include": "#module"
 		}
 	],
 	"repository": {
-		"class-declaration": {
+		"all-types": {
 			"patterns": [
 				{
-					"begin": "\\b(class|interface|enum)\\b",
-					"end": "}",
-					"name": "meta.class-declaration",
-					"beginCaptures": {
-						"1": {
-							"name": "keyword.class"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#keywords"
-						},
-						{
-							"include": "#comments"
-						},
-						{
-							"match": "\\b([a-z]\\w*\\.)*([A-Z]\\w*)\\b",
-							"captures": {
-								"2": {
-									"name": "entity.name.type"
-								}
-							}
-						},
-						{
-							"begin": "{",
-							"end": "(?=})",
-							"name": "meta.class-body",
-							"patterns": [
-								{
-									"include": "#class-declaration"
-								},
-								{
-									"include": "#field-initializer"
-								},
-								{
-									"include": "#method-declaration"
-								},
-								{
-									"include": "#type-parameters-declaration"
-								},
-								{
-									"include": "#block"
-								},
-								{
-									"include": "#annotations"
-								},
-								{
-									"include": "#keywords"
-								},
-								{
-									"include": "#comments"
-								},
-								{
-									"include": "#types"
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-		"field-initializer": {
-			"patterns": [
-				{
-					"begin": "\\=",
-					"end": ";",
-					"name": "meta.field-initializer",
-					"patterns": [
-						{
-							"include": "#expressions"
-						}
-					]
-				}
-			]
-		},
-		"method-declaration": {
-			"patterns": [
-				{
-					"begin": "(\\w+)\\(",
-					"end": "\\)",
-					"name": "meta.method-declaration",
-					"beginCaptures": {
-						"1": {
-							"name": "entity.name.function"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#annotations"
-						},
-						{
-							"include": "#keywords"
-						},
-						{
-							"include": "#comments"
-						},
-						{
-							"include": "#types"
-						}
-					]
-				}
-			]
-		},
-		"type-parameters-declaration": {
-			"match": "<[^<>]+>",
-			"name": "meta.type-parameters-declaration",
-			"captures": {
-				"0": {
-					"patterns": [
-						{
-							"include": "#keywords"
-						},
-						{
-							"include": "#comments"
-						},
-						{
-							"match": "\\b([A-Z]\\w*)\\b",
-							"name": "entity.name.type"
-						}
-					]
-				}
-			}
-		},
-		"block": {
-			"begin": "{",
-			"end": "}",
-			"name": "meta.block",
-			"patterns": [
-				{
-					"include": "#block"
+					"include": "#primitive-arrays"
 				},
 				{
-					"include": "#types"
+					"include": "#primitive-types"
 				},
 				{
-					"include": "#expressions"
+					"include": "#object-types"
 				}
 			]
 		},
 		"annotations": {
 			"patterns": [
 				{
-					"begin": "(@\\s*[^\\s(]+)(\\()",
+					"begin": "((@)\\s*([^\\s(]+))(\\()",
 					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.tag"
-						},
 						"2": {
-							"name": "punctuation.definition.tag.left"
+							"name": "punctuation.definition.annotation.java"
+						},
+						"3": {
+							"name": "storage.type.annotation.java"
+						},
+						"4": {
+							"name": "punctuation.definition.annotation-arguments.begin.bracket.round.java"
 						}
 					},
 					"end": "\\)",
 					"endCaptures": {
 						"0": {
-							"name": "punctuation.definition.tag.right"
+							"name": "punctuation.definition.annotation-arguments.end.bracket.round.java"
 						}
 					},
-					"name": "meta.annotation.java",
+					"name": "meta.declaration.annotation.java",
 					"patterns": [
 						{
 							"captures": {
 								"1": {
-									"name": "punctuation.definition.tag.key"
+									"name": "constant.other.key.java"
 								},
 								"2": {
-									"name": "punctuation.definition.tag.assign"
+									"name": "keyword.operator.assignment.java"
 								}
 							},
 							"match": "(\\w*)\\s*(=)"
 						},
 						{
-							"include": "#keywords"
-						},
-						{
-							"include": "#comments"
-						},
-						{
-							"include": "#constants"
+							"include": "#code"
 						}
 					]
 				},
 				{
-					"match": "@interface\\s+\\w*|@\\s*\\w+",
-					"name": "punctuation.definition.tag"
+					"match": "(@)(interface)\\s+(\\w*)|((@)\\s*(\\w+))",
+					"name": "meta.declaration.annotation.java",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.annotation.java"
+						},
+						"2": {
+							"name": "storage.modifier.java"
+						},
+						"3": {
+							"name": "storage.type.annotation.java"
+						},
+						"5": {
+							"name": "punctuation.definition.annotation.java"
+						},
+						"6": {
+							"name": "storage.type.annotation.java"
+						}
+					}
 				}
 			]
 		},
-		"expressions": {
+		"anonymous-block-and-instance-initializer": {
+			"begin": "{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.block.begin.bracket.curly.java"
+				}
+			},
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.block.end.bracket.curly.java"
+				}
+			},
 			"patterns": [
 				{
-					"include": "#keywords"
+					"include": "#code"
+				}
+			]
+		},
+		"anonymous-classes-and-new": {
+			"begin": "\\bnew\\b",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.control.new.java"
+				}
+			},
+			"end": "(?=;|\\)|\\]|\\.|,|\\?|:|}|\\+|\\-|\\*|\\/(?!\\/|\\*)|%|!|&|\\||\\^|=)",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"begin": "(?<=\\))",
+					"end": "(?=;|\\)|\\]|\\.|,|\\?|:|}|\\+|\\-|\\*|\\/(?!\\/|\\*)|%|!|&|\\||\\^|=)",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.inner-class.begin.bracket.curly.java"
+								}
+							},
+							"end": "}",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.section.inner-class.end.bracket.curly.java"
+								}
+							},
+							"name": "meta.inner-class.java",
+							"patterns": [
+								{
+									"include": "#class-body"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "(?<=\\])",
+					"end": "(?=;|\\)|\\]|\\.|,|\\?|:|}|\\+|\\-|\\*|\\/(?!\\/|\\*)|%|!|&|\\||\\^|=)",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.array-initializer.begin.bracket.curly.java"
+								}
+							},
+							"end": "}",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.section.array-initializer.end.bracket.curly.java"
+								}
+							},
+							"name": "meta.array-initializer.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						}
+					]
+				},
+				{
+					"include": "#parens"
+				}
+			]
+		},
+		"assertions": {
+			"patterns": [
+				{
+					"begin": "\\b(assert)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.assert.java"
+						}
+					},
+					"end": "$",
+					"name": "meta.declaration.assertion.java",
+					"patterns": [
+						{
+							"match": ":",
+							"name": "keyword.operator.assert.expression-separator.java"
+						},
+						{
+							"include": "#code"
+						}
+					]
+				}
+			]
+		},
+		"class": {
+			"begin": "(?=\\w?[\\w\\s-]*\\b(?:class|(?<!@)interface|enum)\\s+[\\w$]+)",
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.class.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.class.java",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#generics"
 				},
 				{
 					"include": "#comments"
 				},
 				{
-					"include": "#constants"
+					"captures": {
+						"1": {
+							"name": "storage.modifier.java"
+						},
+						"2": {
+							"name": "entity.name.type.class.java"
+						}
+					},
+					"match": "(class|(?<!@)interface|enum)\\s+([\\w$]+)",
+					"name": "meta.class.identifier.java"
 				},
 				{
-					"include": "#type-arguments"
+					"begin": "extends",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.modifier.extends.java"
+						}
+					},
+					"end": "(?={|implements|permits)",
+					"name": "meta.definition.class.inherited.classes.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "(implements)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.implements.java"
+						}
+					},
+					"end": "(?=\\s*extends|permits|\\{)",
+					"name": "meta.definition.class.implemented.interfaces.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "(permits)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.permits.java"
+						}
+					},
+					"end": "(?=\\s*extends|implements|\\{)",
+					"name": "meta.definition.class.permits.classes.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.class.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.class.body.java",
+					"patterns": [
+						{
+							"include": "#class-body"
+						}
+					]
+				}
+			]
+		},
+		"class-body": {
+			"patterns": [
+				{
+					"include": "#comments-javadoc"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#enums"
+				},
+				{
+					"include": "#class"
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"include": "#static-initializer"
+				},
+				{
+					"include": "#class-fields-and-methods"
+				},
+				{
+					"include": "#annotations"
+				},
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#member-variables"
+				},
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"class-fields-and-methods": {
+			"patterns": [
+				{
+					"begin": "(?=\\=)",
+					"end": "(?=;)",
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"include": "#methods"
+				}
+			]
+		},
+		"code": {
+			"patterns": [
+				{
+					"include": "#annotations"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#enums"
+				},
+				{
+					"include": "#class"
+				},
+				{
+					"include": "#record"
+				},
+				{
+					"include": "#anonymous-block-and-instance-initializer"
+				},
+				{
+					"include": "#try-catch-finally"
+				},
+				{
+					"include": "#assertions"
 				},
 				{
 					"include": "#parens"
 				},
 				{
-					"begin": "\\(",
-					"end": "\\)",
-					"patterns": [
-						{
-							"include": "#expressions"
-						}
-					]
+					"include": "#constants-and-special-vars"
 				},
 				{
-					"include": "#new"
-				}
-			]
-		},
-		"keywords":  {
-			"patterns": [
+					"include": "#numbers"
+				},
+				{
+					"include": "#anonymous-classes-and-new"
+				},
+				{
+					"include": "#lambda-expression"
+				},
+				{
+					"include": "#keywords"
+				},
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#method-call"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#variables"
+				},
+				{
+					"include": "#variables-local"
+				},
+				{
+					"include": "#objects"
+				},
+				{
+					"include": "#properties"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#all-types"
+				},
 				{
 					"match": ",",
-					"name": "keyword.other.comma"
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.period.java"
 				},
 				{
 					"match": ";",
-					"name": "keyword.other.semi"
-				},
-				{
-					"match": "\\b(package|import)\\b",
-					"name": "keyword.package"
-				},
-				{
-					"match": "\\b(try|catch|finally|throw|throws|return|break|continue|do|for|while|switch|case|if|else|goto|synchronize|assert)\\b",
-					"name": "keyword.control"
-				},
-				{
-					"match": "\\b(instanceof)\\b",
-					"name": "keyword.control"
-				},
-				{
-					"match": "\\.(class)\\b",
-					"captures": {
-						"1": {
-							"name": "keyword.class"
-						}
-					}
-				},
-				{
-					"match": "\\b(default):",
-					"captures": {
-						"1": {
-							"name": "keyword.control.default"
-						}
-					}
-				},
-				{
-					"match": "\\b(private|public|protected|abstract|default(?!=:)|static|final|volatile|const|extends|implements|synchronized)\\b",
-					"name": "storage.modifier.java"
-				},
-				{
-					"match": "\\b(this|super)\\b",
-					"name": "variable.language.java"
-				},
-				{
-					"match": "\\?",
-					"name": "constant.numeric"
-				},
-				{
-					"match": "\\b(byte|short|int|long|char|float|double|boolean|void)\\b",
-					"name": "keyword.type"
-				},
-				{
-					"match": "\\bvar\\b",
-					"name": "keyword.other.var"
+					"name": "punctuation.terminator.java"
 				}
 			]
 		},
 		"comments": {
 			"patterns": [
 				{
-					"begin": "/\\*",
-					"end": "\\*/",
-					"name": "comment.block"
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"match": "/\\*\\*/",
+					"name": "comment.block.empty.java"
 				},
 				{
-					"begin": "//",
-					"end": "$",
-					"name": "comment.line"
+					"include": "#comments-inline"
 				}
 			]
 		},
-		"constants": {
+		"comments-inline": {
 			"patterns": [
 				{
-					"match": "\\b(null|true|false)\\b",
-					"name": "constant.numeric"
+					"begin": "/\\*",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.java"
 				},
 				{
+					"begin": "(^[ \\t]+)?(?=//)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.java"
+						}
+					},
+					"end": "(?!\\G)",
+					"patterns": [
+						{
+							"begin": "//",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.java"
+								}
+							},
+							"end": "\\n",
+							"name": "comment.line.double-slash.java"
+						}
+					]
+				}
+			]
+		},
+		"comments-javadoc": {
+			"patterns": [
+				{
+					"begin": "^\\s*(/\\*\\*)(?!/)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"end": "\\*/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.java"
+						}
+					},
+					"name": "comment.block.javadoc.java",
+					"patterns": [
+						{
+							"match": "@(author|deprecated|return|see|serial|since|version)\\b",
+							"name": "keyword.other.documentation.javadoc.java"
+						},
+						{
+							"match": "(@param)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "keyword.other.documentation.javadoc.java"
+								},
+								"2": {
+									"name": "variable.parameter.java"
+								}
+							}
+						},
+						{
+							"match": "(@(?:exception|throws))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "keyword.other.documentation.javadoc.java"
+								},
+								"2": {
+									"name": "entity.name.type.class.java"
+								}
+							}
+						},
+						{
+							"match": "{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*?}",
+							"captures": {
+								"1": {
+									"name": "keyword.other.documentation.javadoc.java"
+								},
+								"2": {
+									"name": "entity.name.type.class.java"
+								},
+								"3": {
+									"name": "variable.parameter.java"
+								}
+							}
+						}
+					]
+				}
+			]
+		},
+		"constants-and-special-vars": {
+			"patterns": [
+				{
+					"match": "\\b(true|false|null)\\b",
+					"name": "constant.language.java"
+				},
+				{
+					"match": "\\bthis\\b",
+					"name": "variable.language.this.java"
+				},
+				{
+					"match": "\\bsuper\\b",
+					"name": "variable.language.java"
+				}
+			]
+		},
+		"enums": {
+			"begin": "^\\s*([\\w\\s]*)(enum)\\s+(\\w+)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#storage-modifiers"
+						}
+					]
+				},
+				"2": {
+					"name": "storage.modifier.java"
+				},
+				"3": {
+					"name": "entity.name.type.enum.java"
+				}
+			},
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.enum.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.enum.java",
+			"patterns": [
+				{
+					"begin": "\\b(extends)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.extends.java"
+						}
+					},
+					"end": "(?={|\\bimplements\\b)",
+					"name": "meta.definition.class.inherited.classes.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "\\b(implements)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.implements.java"
+						}
+					},
+					"end": "(?={|\\bextends\\b)",
+					"name": "meta.definition.class.implemented.interfaces.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.enum.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"patterns": [
+						{
+							"begin": "(?<={)",
+							"end": "(?=;|})",
+							"patterns": [
+								{
+									"include": "#comments-javadoc"
+								},
+								{
+									"include": "#comments"
+								},
+								{
+									"begin": "\\b(\\w+)\\b",
+									"beginCaptures": {
+										"1": {
+											"name": "constant.other.enum.java"
+										}
+									},
+									"end": "(,)|(?=;|})",
+									"endCaptures": {
+										"1": {
+											"name": "punctuation.separator.delimiter.java"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#comments-javadoc"
+										},
+										{
+											"include": "#comments"
+										},
+										{
+											"begin": "\\(",
+											"beginCaptures": {
+												"0": {
+													"name": "punctuation.bracket.round.java"
+												}
+											},
+											"end": "\\)",
+											"endCaptures": {
+												"0": {
+													"name": "punctuation.bracket.round.java"
+												}
+											},
+											"patterns": [
+												{
+													"include": "#code"
+												}
+											]
+										},
+										{
+											"begin": "{",
+											"beginCaptures": {
+												"0": {
+													"name": "punctuation.bracket.curly.java"
+												}
+											},
+											"end": "}",
+											"endCaptures": {
+												"0": {
+													"name": "punctuation.bracket.curly.java"
+												}
+											},
+											"patterns": [
+												{
+													"include": "#class-body"
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"include": "#class-body"
+						}
+					]
+				}
+			]
+		},
+		"function-call": {
+			"begin": "([A-Za-z_$][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.java"
+				},
+				"2": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.java"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.java"
+				}
+			},
+			"name": "meta.function-call.java",
+			"patterns": [
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"generics": {
+			"begin": "<",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.bracket.angle.java"
+				}
+			},
+			"end": ">",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.bracket.angle.java"
+				}
+			},
+			"patterns": [
+				{
+					"match": "\\b(extends|super)\\b",
+					"name": "storage.modifier.$1.java"
+				},
+				{
+					"match": "(?<!\\.)([a-zA-Z$_][a-zA-Z0-9$_]*)(?=\\s*<)",
+					"captures": {
+						"1": {
+							"name": "storage.type.java"
+						}
+					}
+				},
+				{
+					"include": "#primitive-arrays"
+				},
+				{
+					"match": "[a-zA-Z$_][a-zA-Z0-9$_]*",
+					"name": "storage.type.generic.java"
+				},
+				{
+					"match": "\\?",
+					"name": "storage.type.generic.wildcard.java"
+				},
+				{
+					"match": "&",
+					"name": "punctuation.separator.types.java"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "\\.",
+					"name": "punctuation.separator.period.java"
+				},
+				{
+					"include": "#parens"
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"match": "\\bthrow\\b",
+					"name": "keyword.control.throw.java"
+				},
+				{
+					"match": "\\?|:",
+					"name": "keyword.control.ternary.java"
+				},
+				{
+					"match": "\\b(return|yield|break|case|continue|default|do|while|for|switch|if|else)\\b",
+					"name": "keyword.control.java"
+				},
+				{
+					"match": "\\b(instanceof)\\b",
+					"name": "keyword.operator.instanceof.java"
+				},
+				{
+					"match": "(<<|>>>?|~|\\^)",
+					"name": "keyword.operator.bitwise.java"
+				},
+				{
+					"match": "((&|\\^|\\||<<|>>>?)=)",
+					"name": "keyword.operator.assignment.bitwise.java"
+				},
+				{
+					"match": "(===?|!=|<=|>=|<>|<|>)",
+					"name": "keyword.operator.comparison.java"
+				},
+				{
+					"match": "([+*/%-]=)",
+					"name": "keyword.operator.assignment.arithmetic.java"
+				},
+				{
+					"match": "(=)",
+					"name": "keyword.operator.assignment.java"
+				},
+				{
+					"match": "(\\-\\-|\\+\\+)",
+					"name": "keyword.operator.increment-decrement.java"
+				},
+				{
+					"match": "(\\-|\\+|\\*|\\/|%)",
+					"name": "keyword.operator.arithmetic.java"
+				},
+				{
+					"match": "(!|&&|\\|\\|)",
+					"name": "keyword.operator.logical.java"
+				},
+				{
+					"match": "(\\||&)",
+					"name": "keyword.operator.bitwise.java"
+				},
+				{
+					"match": "\\b(const|goto)\\b",
+					"name": "keyword.reserved.java"
+				}
+			]
+		},
+		"lambda-expression": {
+			"patterns": [
+				{
+					"match": "->",
+					"name": "storage.type.function.arrow.java"
+				}
+			]
+		},
+		"member-variables": {
+			"begin": "(?=private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final)",
+			"end": "(?=\\=|;)",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#variables"
+				},
+				{
+					"include": "#primitive-arrays"
+				},
+				{
+					"include": "#object-types"
+				}
+			]
+		},
+		"method-call": {
+			"begin": "(\\.)\\s*([A-Za-z_$][\\w$]*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.separator.period.java"
+				},
+				"2": {
+					"name": "entity.name.function.java"
+				},
+				"3": {
+					"name": "punctuation.definition.parameters.begin.bracket.round.java"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.bracket.round.java"
+				}
+			},
+			"name": "meta.method-call.java",
+			"patterns": [
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"methods": {
+			"begin": "(?!new)(?=[\\w<].*\\s+)(?=([^=/]|/(?!/))+\\()",
+			"end": "(})|(?=;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.method.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.method.java",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"begin": "(\\w+)\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.java"
+						},
+						"2": {
+							"name": "punctuation.definition.parameters.begin.bracket.round.java"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.parameters.end.bracket.round.java"
+						}
+					},
+					"name": "meta.method.identifier.java",
+					"patterns": [
+						{
+							"include": "#parameters"
+						},
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"begin": "(?=\\w.*\\s+\\w+\\s*\\()",
+					"end": "(?=\\s+\\w+\\s*\\()",
+					"name": "meta.method.return-type.java",
+					"patterns": [
+						{
+							"include": "#all-types"
+						},
+						{
+							"include": "#parens"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"include": "#throws"
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.method.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.method.body.java",
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		},
+		"module": {
+			"begin": "((open)\\s)?(module)\\s+(\\w+)",
+			"end": "}",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.java"
+				},
+				"3": {
+					"name": "storage.modifier.java"
+				},
+				"4": {
+					"name": "entity.name.type.module.java"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.module.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.module.java",
+			"patterns": [
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.module.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.module.body.java",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#comments-javadoc"
+						},
+						{
+							"match": "\\b(requires|transitive|exports|opens|to|uses|provides|with)\\b",
+							"name": "keyword.module.java"
+						}
+					]
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
 					"match": "(?x)\n\\b(?<!\\$)\n0(x|X)\n(\n  (?<!\\.)[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?[Ll]?(?!\\.)\n  |\n  (\n    [0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\\.?\n    |\n    ([0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?)?\\.[0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?\n  )\n  [Pp][+-]?[0-9]([0-9_]*[0-9])?[FfDd]?\n)\n\\b(?!\\$)",
-					"name": "constant.numeric.hex"
+					"name": "constant.numeric.hex.java"
 				},
 				{
 					"match": "\\b(?<!\\$)0(b|B)[01]([01_]*[01])?[Ll]?\\b(?!\\$)",
-					"name": "constant.numeric.binary"
+					"name": "constant.numeric.binary.java"
 				},
 				{
 					"match": "\\b(?<!\\$)0[0-7]([0-7_]*[0-7])?[Ll]?\\b(?!\\$)",
-					"name": "constant.numeric.octal"
+					"name": "constant.numeric.octal.java"
 				},
 				{
 					"match": "(?x)\n(?<!\\$)\n(\n  \\b[0-9]([0-9_]*[0-9])?\\.\\B(?!\\.)\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?\\.([0-9]([0-9_]*[0-9])?)([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  (?<!\\.)\\B\\.[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)[FfDd]?\\b\n  |\n  \\b[0-9]([0-9_]*[0-9])?([Ee][+-]?[0-9]([0-9_]*[0-9])?)?[FfDd]\\b\n  |\n  \\b(0|[1-9]([0-9_]*[0-9])?)(?!\\.)[Ll]?\\b\n)\n(?!\\$)",
-					"name": "constant.numeric.decimal"
+					"name": "constant.numeric.decimal.java"
+				}
+			]
+		},
+		"object-types": {
+			"patterns": [
+				{
+					"include": "#generics"
+				},
+				{
+					"begin": "\\b((?:[A-Za-z_]\\w*\\s*\\.\\s*)*)([A-Z_]\\w*)\\s*(?=\\[)",
+					"beginCaptures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "[A-Za-z_]\\w*",
+									"name": "storage.type.java"
+								},
+								{
+									"match": "\\.",
+									"name": "punctuation.separator.period.java"
+								}
+							]
+						},
+						"2": {
+							"name": "storage.type.object.array.java"
+						}
+					},
+					"end": "(?!\\s*\\[)",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#parens"
+						}
+					]
+				},
+				{
+					"match": "\\b((?:[A-Za-z_]\\w*\\s*\\.\\s*)*[A-Z_]\\w*)\\s*(?=<)",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "[A-Za-z_]\\w*",
+									"name": "storage.type.java"
+								},
+								{
+									"match": "\\.",
+									"name": "punctuation.separator.period.java"
+								}
+							]
+						}
+					}
+				},
+				{
+					"match": "\\b((?:[A-Za-z_]\\w*\\s*\\.\\s*)*[A-Z_]\\w*)\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"match": "[A-Za-z_]\\w*",
+									"name": "storage.type.java"
+								},
+								{
+									"match": "\\.",
+									"name": "punctuation.separator.period.java"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"object-types-inherited": {
+			"patterns": [
+				{
+					"include": "#generics"
+				},
+				{
+					"match": "\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b",
+					"name": "entity.other.inherited-class.java",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						}
+					}
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				}
+			]
+		},
+		"objects": {
+			"match": "(?<![\\w$])[a-zA-Z_$][\\w$]*(?=\\s*\\.\\s*[\\w$]+)",
+			"name": "variable.other.object.java"
+		},
+		"parameters": {
+			"patterns": [
+				{
+					"match": "\\bfinal\\b",
+					"name": "storage.modifier.java"
+				},
+				{
+					"include": "#annotations"
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"match": "\\w+",
+					"name": "variable.parameter.java"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
+				},
+				{
+					"match": "\\.\\.\\.",
+					"name": "punctuation.definition.parameters.varargs.java"
+				}
+			]
+		},
+		"parens": {
+			"patterns": [
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.bracket.round.java"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.bracket.round.java"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"begin": "\\[",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.bracket.square.java"
+						}
+					},
+					"end": "\\]",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.bracket.square.java"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.bracket.curly.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.bracket.curly.java"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				}
+			]
+		},
+		"primitive-arrays": {
+			"patterns": [
+				{
+					"begin": "\\b(void|boolean|byte|char|short|int|float|long|double)\\b\\s*(?=\\[)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.primitive.array.java"
+						}
+					},
+					"end": "(?!\\s*\\[)",
+					"patterns": [
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#parens"
+						}
+					]
+				}
+			]
+		},
+		"primitive-types": {
+			"match": "\\b(void|boolean|byte|char|short|int|float|long|double)\\b",
+			"name": "storage.type.primitive.java"
+		},
+		"properties": {
+			"patterns": [
+				{
+					"match": "(\\.)\\s*(new)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "keyword.control.new.java"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([a-zA-Z_$][\\w$]*)(?=\\s*\\.\\s*[a-zA-Z_$][\\w$]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "variable.other.object.property.java"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([a-zA-Z_$][\\w$]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "variable.other.object.property.java"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([0-9][\\w$]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.period.java"
+						},
+						"2": {
+							"name": "invalid.illegal.identifier.java"
+						}
+					}
+				}
+			]
+		},
+		"record": {
+			"begin": "(?=\\w?[\\w\\s]*\\b(?:record)\\s+[\\w$]+)",
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.class.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.record.java",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"include": "#generics"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": "(record)\\s+([\\w$]+)(<[\\w$]+>)?(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.java"
+						},
+						"2": {
+							"name": "entity.name.type.record.java"
+						},
+						"3": {
+							"patterns": [
+								{
+									"include": "#generics"
+								}
+							]
+						},
+						"4": {
+							"name": "punctuation.definition.parameters.begin.bracket.round.java"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.parameters.end.bracket.round.java"
+						}
+					},
+					"name": "meta.record.identifier.java",
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				},
+				{
+					"begin": "(implements)\\s",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.modifier.implements.java"
+						}
+					},
+					"end": "(?=\\s*\\{)",
+					"name": "meta.definition.class.implemented.interfaces.java",
+					"patterns": [
+						{
+							"include": "#object-types-inherited"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"include": "#record-body"
+				}
+			]
+		},
+		"record-body": {
+			"begin": "{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.class.begin.bracket.curly.java"
+				}
+			},
+			"end": "(?=})",
+			"name": "meta.record.body.java",
+			"patterns": [
+				{
+					"include": "#record-constructor"
+				},
+				{
+					"include": "#class-body"
+				}
+			]
+		},
+		"record-constructor": {
+			"begin": "(?!new)(?=[\\w<].*\\s+)(?=([^\\(=/]|/(?!/))+(?={))",
+			"end": "(})|(?=;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.method.end.bracket.curly.java"
+				}
+			},
+			"name": "meta.method.java",
+			"patterns": [
+				{
+					"include": "#storage-modifiers"
+				},
+				{
+					"begin": "(\\w+)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.java"
+						}
+					},
+					"end": "(?=\\s*{)",
+					"name": "meta.method.identifier.java",
+					"patterns": [
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.method.begin.bracket.curly.java"
+						}
+					},
+					"end": "(?=})",
+					"contentName": "meta.method.body.java",
+					"patterns": [
+						{
+							"include": "#code"
+						}
+					]
+				}
+			]
+		},
+		"static-initializer": {
+			"patterns": [
+				{
+					"include": "#anonymous-block-and-instance-initializer"
+				},
+				{
+					"match": "static",
+					"name": "storage.modifier.java"
+				}
+			]
+		},
+		"storage-modifiers": {
+			"match": "\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp|sealed|non-sealed)\\b",
+			"name": "storage.modifier.java"
+		},
+		"strings": {
+			"patterns": [
+				{
+					"begin": "\"\"\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.java"
+						}
+					},
+					"end": "\"\"\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.java"
+						}
+					},
+					"name": "string.quoted.triple.java",
+					"patterns": [
+						{
+							"match": "(\\\\\"\"\")(?!\")|(\\\\.)",
+							"name": "constant.character.escape.java"
+						}
+					]
 				},
 				{
 					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.java"
+						}
+					},
 					"end": "\"",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.java"
+						}
+					},
 					"name": "string.quoted.double.java",
 					"patterns": [
 						{
 							"match": "\\\\.",
-							"name": "constant.character.escape"
+							"name": "constant.character.escape.java"
 						}
 					]
 				},
 				{
 					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.java"
+						}
+					},
 					"end": "'",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.java"
+						}
+					},
 					"name": "string.quoted.single.java",
 					"patterns": [
 						{
 							"match": "\\\\.",
-							"name": "constant.character.escape"
+							"name": "constant.character.escape.java"
 						}
 					]
 				}
 			]
 		},
-		"types": {
+		"throws": {
+			"begin": "throws",
+			"beginCaptures": {
+				"0": {
+					"name": "storage.modifier.java"
+				}
+			},
+			"end": "(?={|;)",
+			"name": "meta.throwables.java",
 			"patterns": [
 				{
-					"match": "\\b([a-z]\\w*\\.)*([A-Z]\\w*) +(?=\\w)",
-					"captures": {
-						"2": {
-							"name": "entity.name.type"
-						}
-					}
+					"match": ",",
+					"name": "punctuation.separator.delimiter.java"
 				},
 				{
-					"match": "\\b([a-z]\\w*\\.)*([A-Z]\\w*) *(\\[\\])+",
-					"captures": {
-						"2": {
-							"name": "entity.name.type"
-						}
-					}
+					"match": "[a-zA-Z$_][\\.a-zA-Z0-9$_]*",
+					"name": "storage.type.java"
 				},
 				{
-					"match": "\\b(\\w+) *(?<GROUP><([^<>]|\\g<GROUP>)*>)",
-					"captures": {
-						"1": {
-							"name": "entity.name.type"
-						},
-						"2": {
-							"name": "meta.type-parameters-declaration",
-							"patterns": [
-								{
-									"include": "#keywords"
-								},
-								{
-									"include": "#comments"
-								},
-								{
-									"match": "\\b([a-z]\\w*\\.)*([A-Z]\\w*)\\b",
-									"captures": {
-										"2": {
-											"name": "entity.name.type"
-										}
-									}
-								}
-							]
-						}
-					}
+					"include": "#comments"
 				}
 			]
 		},
-		"new": {
-			"begin": "\\b(new)\\b",
-			"end": "(?=;|\\)|\\.|,|:|}|=)",
-			"name": "meta.new",
-			"captures": {
-				"1": {
-					"name": "keyword.control"
-				}
-			},
+		"try-catch-finally": {
 			"patterns": [
 				{
-					"include": "#expressions"
-				},
-				{
-					"match": "\\b([a-z]\\w*\\.)*([A-Z]\\w*)\\b",
-					"captures": {
-						"2": {
-							"name": "entity.name.type"
+					"begin": "\\btry\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.try.java"
 						}
-					}
-				},
-				{
-					"begin": "{",
+					},
 					"end": "}",
-					"name": "meta.anonymous-class",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.try.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.try.java",
 					"patterns": [
 						{
-							"include": "#class-declaration"
+							"begin": "\\(",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.try.resources.begin.bracket.round.java"
+								}
+							},
+							"end": "\\)",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.section.try.resources.end.bracket.round.java"
+								}
+							},
+							"name": "meta.try.resources.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
 						},
 						{
-							"include": "#field-initializer"
-						},
-						{
-							"include": "#method-declaration"
-						},
-						{
-							"include": "#type-parameters-declaration"
-						},
-						{
-							"include": "#block"
-						},
-						{
-							"include": "#annotations"
-						},
-						{
-							"include": "#keywords"
-						},
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.try.begin.bracket.curly.java"
+								}
+							},
+							"end": "(?=})",
+							"contentName": "meta.try.body.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "\\b(catch)\\b",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.catch.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.catch.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.catch.java",
+					"patterns": [
 						{
 							"include": "#comments"
 						},
 						{
-							"include": "#types"
+							"begin": "\\(",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.parameters.begin.bracket.round.java"
+								}
+							},
+							"end": "\\)",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.definition.parameters.end.bracket.round.java"
+								}
+							},
+							"contentName": "meta.catch.parameters.java",
+							"patterns": [
+								{
+									"include": "#comments"
+								},
+								{
+									"include": "#storage-modifiers"
+								},
+								{
+									"begin": "[a-zA-Z$_][\\.a-zA-Z0-9$_]*",
+									"beginCaptures": {
+										"0": {
+											"name": "storage.type.java"
+										}
+									},
+									"end": "(\\|)|(?=\\))",
+									"endCaptures": {
+										"1": {
+											"name": "punctuation.catch.separator.java"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#comments"
+										},
+										{
+											"match": "\\w+",
+											"captures": {
+												"0": {
+													"name": "variable.parameter.java"
+												}
+											}
+										}
+									]
+								}
+							]
+						},
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.catch.begin.bracket.curly.java"
+								}
+							},
+							"end": "(?=})",
+							"contentName": "meta.catch.body.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
+						}
+					]
+				},
+				{
+					"begin": "\\bfinally\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.finally.java"
+						}
+					},
+					"end": "}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.finally.end.bracket.curly.java"
+						}
+					},
+					"name": "meta.finally.java",
+					"patterns": [
+						{
+							"begin": "{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.section.finally.begin.bracket.curly.java"
+								}
+							},
+							"end": "(?=})",
+							"contentName": "meta.finally.body.java",
+							"patterns": [
+								{
+									"include": "#code"
+								}
+							]
 						}
 					]
 				}
 			]
 		},
-		"type-arguments": {
+		"variables": {
+			"begin": "(?x)\n(?=\n  \\b\n  (\n    (void|boolean|byte|char|short|int|float|long|double)\n    |\n    (?>(\\w+\\.)*[A-Z_]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`\n  )\n  \\b\n  \\s*\n  (\n    <[\\w<>,\\.?\\s\\[\\]]*> # e.g. `HashMap<Integer, String>`, or `List<java.lang.String>`\n  )?\n  \\s*\n  (\n    (\\[\\])* # int[][]\n  )?\n  \\s+\n  [A-Za-z_$][\\w$]* # At least one identifier after space\n  ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers\n  \\s*(=|:|;)\n)",
+			"end": "(?=\\=|:|;)",
+			"name": "meta.definition.variable.java",
 			"patterns": [
 				{
-					"match": "\\.(?<GROUP><([^<>]|\\g<GROUP>)*>)",
-					"name": "meta.type-arguments",
+					"match": "([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|:|=|,))",
 					"captures": {
 						"1": {
-							"patterns": [
-								{
-									"include": "#keywords"
-								},
-								{
-									"include": "#comments"
-								},
-								{
-									"match": "\\b([a-z]\\w*\\.)*([A-Z]\\w*)\\b",
-									"captures": {
-										"2": {
-											"name": "entity.name.type"
-										}
-									}
-								}
-							]
+							"name": "variable.other.definition.java"
 						}
 					}
+				},
+				{
+					"include": "#all-types"
+				},
+				{
+					"include": "#code"
+				}
+			]
+		},
+		"variables-local": {
+			"begin": "(?=\\b(var)\\b\\s+[A-Za-z_$][\\w$]*\\s*(=|:|;))",
+			"end": "(?=\\=|:|;)",
+			"name": "meta.definition.variable.local.java",
+			"patterns": [
+				{
+					"match": "\\bvar\\b",
+					"name": "storage.type.local.java"
+				},
+				{
+					"match": "([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(=|:|;))",
+					"captures": {
+						"1": {
+							"name": "variable.other.definition.java"
+						}
+					}
+				},
+				{
+					"include": "#code"
 				}
 			]
 		}


### PR DESCRIPTION
Copied from https://github.com/redhat-developer/vscode-java/blob/70ebc3eec19f0e827734b9a20f016e92433c834d/language-support/java/java.tmLanguage.json, which is what the VSCode integrated Java textmate grammar uses.

This grammar covers many more language features (e.g. multi-line text blocks).

Differences I can see (not all shown in the screenshots) are;
- Annotations are now consistently colored and use the same color as `class` and `interface` declaration names.
- `true`/`false`/`null` colors now match that of other languages (now blue where before it was light green).
- The static class property `class` is now colored the same as normal properties (I'd personally classify this as a regression since the prior grammar explicitly classifies it as `keyword.class`, although this seems more like an opinion).
- Many more (but not all) variables/fields/properties are colored.

There are likely plenty more differences. If a more exhaustive comparison is desired let me know and I'll get the current and proposed extensions running side-by-side (its a bit of work right now as 2 fully functional environments are required, doable but tedious).

### Current

![image](https://github.com/georgewfraser/java-language-server/assets/17376090/febe5097-3735-4d3c-80cc-8a0664243c32)

### VSCode Builtin (Red Hat)

![image](https://github.com/georgewfraser/java-language-server/assets/17376090/c155c0e1-8f68-479e-beba-2ecbbfcaac43)

### PR

![image](https://github.com/georgewfraser/java-language-server/assets/17376090/64fa35b5-d8ed-4eb8-8e68-42f7f4894d0b)
