### PR TITLE
Fix IndexOutOfBoundException on finding references

### DIFF
--- a/src/main/java/org/javacs/navigation/FindReferences.java
+++ b/src/main/java/org/javacs/navigation/FindReferences.java
@@ -4,6 +4,7 @@ import com.sun.source.tree.*;
 import com.sun.source.util.*;
 import java.util.List;
 import javax.lang.model.element.Element;
+import javax.tools.Diagnostic;
 
 class FindReferences extends TreePathScanner<Void, List<TreePath>> {
     final JavacTask task;
@@ -47,7 +48,18 @@ class FindReferences extends TreePathScanner<Void, List<TreePath>> {
     }
 
     private boolean check() {
-        var candidate = Trees.instance(task).getElement(getCurrentPath());
-        return find.equals(candidate);
+        var path = getCurrentPath();
+        var trees = Trees.instance(task);
+        var candidate = trees.getElement(path);
+        if (!find.equals(candidate)) {
+            return false;
+        }
+        var pos = trees.getSourcePositions();
+        // Skip elements without positions. This can happen, e.g. for var types.
+        if (pos.getStartPosition(path.getCompilationUnit(), path.getLeaf()) == Diagnostic.NOPOS ||
+            pos.getEndPosition(path.getCompilationUnit(), path.getLeaf()) == Diagnostic.NOPOS) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/test/examples/maven-project/src/org/javacs/example/VarTypeReferences.java
+++ b/src/test/examples/maven-project/src/org/javacs/example/VarTypeReferences.java
@@ -1,0 +1,12 @@
+package org.javacs.example;
+
+public class VarTypeReferences {
+    private static class Foo {
+        public void foo() {}
+    }
+
+    public void run() {
+        var foo = new Foo();
+        foo.foo();
+    }
+}

--- a/src/test/java/org/javacs/FindReferencesTest.java
+++ b/src/test/java/org/javacs/FindReferencesTest.java
@@ -56,4 +56,9 @@ public class FindReferencesTest {
         assertThat(items(file, 4, 12), contains("StackedFieldReferences.java(8)"));
         assertThat(items(file, 4, 15), contains("StackedFieldReferences.java(9)"));
     }
+
+    @Test
+    public void varTypeReferences() {
+        assertThat(items("/org/javacs/example/VarTypeReferences.java", 4, 27), contains("VarTypeReferences.java(9)"));
+    }
 }


### PR DESCRIPTION
It is possible that the matching type does not appear directly in the AST, e.g. when a type is referenced with "var". This patch fixes the issue by skipping such matches.

Fixes #297.