### PR TITLE
Autoimport completed class names

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,15 @@
                     ],
                     "default": "off",
                     "description": "Traces the communication between VSCode and the language server."
+                },
+                "java.importOrder": {
+                    "type": "string",
+                    "enum": [
+                        "simple",
+                        "chromium"
+                    ],
+                    "default": "simple",
+                    "description": "Import order for organizing imports."
                 }
             }
         },

--- a/src/main/java/org/javacs/action/CodeActionProvider.java
+++ b/src/main/java/org/javacs/action/CodeActionProvider.java
@@ -13,14 +13,17 @@ import java.util.regex.Pattern;
 import javax.lang.model.element.*;
 import org.javacs.*;
 import org.javacs.FindTypeDeclarationAt;
+import org.javacs.imports.AutoImportProvider;
 import org.javacs.lsp.*;
 import org.javacs.rewrite.*;
 
 public class CodeActionProvider {
     private final CompilerProvider compiler;
+    private final AutoImportProvider autoImportProvider;
 
-    public CodeActionProvider(CompilerProvider compiler) {
+    public CodeActionProvider(CompilerProvider compiler, AutoImportProvider autoImportProvider) {
         this.compiler = compiler;
+        this.autoImportProvider = autoImportProvider;
     }
 
     public List<CodeAction> codeActionsForCursor(CodeActionParams params) {
@@ -171,7 +174,7 @@ public class CodeActionProvider {
                 for (var qualifiedName : compiler.publicTopLevelTypes()) {
                     if (qualifiedName.endsWith("." + simpleName)) {
                         var title = "Import '" + qualifiedName + "'";
-                        var addImport = new AddImport(file, qualifiedName);
+                        var addImport = new AddImport(file, qualifiedName, autoImportProvider);
                         allImports.addAll(createQuickFix(title, addImport));
                     }
                 }

--- a/src/main/java/org/javacs/imports/AutoImportProvider.java
+++ b/src/main/java/org/javacs/imports/AutoImportProvider.java
@@ -1,0 +1,16 @@
+package org.javacs.imports;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.util.SourcePositions;
+import java.util.List;
+import org.javacs.lsp.TextEdit;
+
+/**
+ * Provides the functionality to auto-import classes.
+ */
+public interface AutoImportProvider {
+    /**
+     * Computes edits to add an import statement of the given class name to the Java file.
+     */
+    List<TextEdit> addImport(String className, CompilationUnitTree root, SourcePositions sourcePositions);
+}

--- a/src/main/java/org/javacs/imports/AutoImportProviderFactory.java
+++ b/src/main/java/org/javacs/imports/AutoImportProviderFactory.java
@@ -1,0 +1,21 @@
+package org.javacs.imports;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.util.SourcePositions;
+import org.javacs.lsp.TextEdit;
+
+/**
+ * The factory of AutoImportProvider.
+ */
+public class AutoImportProviderFactory {
+    public static AutoImportProvider getByName(String name) {
+        switch (name) {
+            case "", "default", "simple":
+                return SimpleAutoImportProvider.INSTANCE;
+            case "chromium":
+                return ChromiumAutoImportProvider.INSTANCE;
+            default:
+                throw new IllegalArgumentException("Unknown import order: " + name);
+        }
+    }
+}

--- a/src/main/java/org/javacs/imports/ChromiumAutoImportProvider.java
+++ b/src/main/java/org/javacs/imports/ChromiumAutoImportProvider.java
@@ -1,0 +1,62 @@
+package org.javacs.imports;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.util.SourcePositions;
+import java.util.List;
+import javax.tools.Diagnostic;
+import org.javacs.lsp.Position;
+import org.javacs.lsp.Range;
+import org.javacs.lsp.TextEdit;
+
+/**
+ * The import order for Chromium Java source files.
+ *
+ * https://chromium.googlesource.com/chromium/src/+/main/styleguide/java/java.md#import-order
+ */
+public class ChromiumAutoImportProvider implements AutoImportProvider {
+    public static final ChromiumAutoImportProvider INSTANCE = new ChromiumAutoImportProvider();
+
+    private final SectionedImportOrderHelper helper = new SectionedImportOrderHelper(ChromiumAutoImportProvider::sectionOf);
+
+    private ChromiumAutoImportProvider() {}
+
+    @Override
+    public List<TextEdit> addImport(String className, CompilationUnitTree root, SourcePositions sourcePositions) {
+        return helper.addImport(className, root, sourcePositions);
+    }
+
+    private static int sectionOf(String className) {
+        if (className.startsWith("com.google.android.apps.chrome.")) {
+            return 7;
+        }
+        if (className.startsWith("org.chromium.")) {
+            return 8;
+        }
+        if (className.startsWith("android.")) {
+            return 1;
+        }
+        if (className.startsWith("androidx.")) {
+            return 2;
+        }
+        if (className.startsWith("com.")) {
+            return 3;
+        }
+        if (className.startsWith("dalvik.")) {
+            return 4;
+        }
+        if (className.startsWith("junit.")) {
+            return 5;
+        }
+        if (className.startsWith("org.")) {
+            return 6;
+        }
+        if (className.startsWith("java.")) {
+            return 9;
+        }
+        if (className.startsWith("javax.")) {
+            return 10;
+        }
+        return 99;
+    }
+}

--- a/src/main/java/org/javacs/imports/ChromiumAutoImportProvider.java
+++ b/src/main/java/org/javacs/imports/ChromiumAutoImportProvider.java
@@ -26,7 +26,10 @@ public class ChromiumAutoImportProvider implements AutoImportProvider {
         return helper.addImport(className, root, sourcePositions);
     }
 
-    private static int sectionOf(String className) {
+    private static int sectionOf(String className, boolean isStatic) {
+        if (isStatic) {
+            return 0;
+        }
         if (className.startsWith("com.google.android.apps.chrome.")) {
             return 7;
         }

--- a/src/main/java/org/javacs/imports/SectionedImportOrderHelper.java
+++ b/src/main/java/org/javacs/imports/SectionedImportOrderHelper.java
@@ -1,0 +1,113 @@
+package org.javacs.imports;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.util.SourcePositions;
+import java.util.List;
+import javax.tools.Diagnostic;
+import org.javacs.lsp.Position;
+import org.javacs.lsp.Range;
+import org.javacs.lsp.TextEdit;
+
+/**
+ * A common logic to implement AutoImportProvider that organizes imports into one or more sections.
+ */
+class SectionedImportOrderHelper {
+    /**
+     * Decides which section a class name belongs to.
+     *
+     * It should return an integer that represents a section. Sections are organized in the
+     * increasing order.
+     */
+    public interface SectionFunction {
+        int sectionOf(String className);
+    }
+
+    private final SectionFunction sectionFunction;
+
+    public SectionedImportOrderHelper(SectionFunction sectionFunction) {
+        this.sectionFunction = sectionFunction;
+    }
+
+    public List<TextEdit> addImport(String className, CompilationUnitTree root, SourcePositions sourcePositions) {
+        String importCode = "import " + className + ";\n";
+        var lineMap = root.getLineMap();
+        var imports = root.getImports();
+
+        // No need to import java.lang.*.
+        if (className.startsWith("java.lang.")) {
+            return List.of();
+        }
+
+        // If there is already an import, do not insert one.
+        for (var i : imports) {
+            String importedClassName = i.getQualifiedIdentifier().toString();
+            if (importedClassName.equals(className)) {
+                return List.of();
+            }
+            if (importedClassName.endsWith(".*")) {
+                String importedPackage = importedClassName.substring(0, importedClassName.length() - 1);
+                if (className.startsWith(importedPackage)) {
+                    return List.of();
+                }
+            }
+        }
+
+        // Special logic to handle the case of no imports yet.
+        if (imports.isEmpty()) {
+            var packageTree = root.getPackage();
+            if (packageTree == null) {
+                // There is even no package declaration.
+                return List.of(new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), importCode));
+            }
+            var packageStartPos = sourcePositions.getStartPosition(root, root.getPackage());
+            var packageLine = (int) lineMap.getLineNumber(packageStartPos) - 1;
+            var editPosition = new Position(packageLine + 1, 0);
+            return List.of(new TextEdit(new Range(editPosition, editPosition), "\n" + importCode));
+        }
+
+        // Find the position to insert a new import.
+        int newImportSection = sectionFunction.sectionOf(className);
+        int insertPosition = imports.size();
+        for (var i = 0; i < imports.size(); i++) {
+            String nextClassName = imports.get(i).getQualifiedIdentifier().toString();
+            int nextImportSection = sectionFunction.sectionOf(nextClassName);
+            if (nextImportSection > newImportSection || (nextImportSection == newImportSection && nextClassName.compareTo(className) > 0)) {
+                insertPosition = i;
+                break;
+            }
+        }
+
+        if (insertPosition == imports.size()) {
+            // Add to the end.
+            var lastImport = imports.get(imports.size() - 1);
+            int lastImportSection = sectionFunction.sectionOf(lastImport.getQualifiedIdentifier().toString());
+            String insertCode = importCode;
+            if (lastImportSection < newImportSection) {
+                insertCode = "\n" + insertCode;
+            }
+            var lastImportStartPos = sourcePositions.getStartPosition(root, lastImport);
+            var lastImportLine = (int) lineMap.getLineNumber(lastImportStartPos) - 1;
+            var editPosition = new Position(lastImportLine + 1, 0);
+            return List.of(new TextEdit(new Range(editPosition, editPosition), insertCode));
+        }
+
+        // Insert to the beginning or the middle.
+        var nextImport = imports.get(insertPosition);
+        int nextImportSection = sectionFunction.sectionOf(nextImport.getQualifiedIdentifier().toString());
+        var nextImportStartPos = sourcePositions.getStartPosition(root, nextImport);
+        var nextImportLine = (int) lineMap.getLineNumber(nextImportStartPos) - 1;
+        var editPosition = new Position(nextImportLine, 0);
+        String insertCode = importCode;
+        if (newImportSection < nextImportSection) {
+            if (insertPosition > 0 && sectionFunction.sectionOf(imports.get(insertPosition - 1).getQualifiedIdentifier().toString()) == newImportSection) {
+                // Append an import to the end of the previous section.
+                editPosition.line--;
+            } else {
+                // Create a new section.
+                insertCode += "\n";
+            }
+        }
+        return List.of(new TextEdit(new Range(editPosition, editPosition), insertCode));
+    }
+}

--- a/src/main/java/org/javacs/imports/SectionedImportOrderHelper.java
+++ b/src/main/java/org/javacs/imports/SectionedImportOrderHelper.java
@@ -109,8 +109,8 @@ class SectionedImportOrderHelper {
         var editPosition = new Position(nextImportLine, 0);
         String insertCode = importCode;
         if (newImportSection < nextImportSection) {
-            var previousImport = imports.get(insertPosition - 1);
-            if (insertPosition > 0 && sectionFunction.sectionOf(previousImport.getQualifiedIdentifier().toString(), previousImport.isStatic()) == newImportSection) {
+            var previousImport = insertPosition > 0 ? imports.get(insertPosition - 1) : null;
+            if (previousImport != null && sectionFunction.sectionOf(previousImport.getQualifiedIdentifier().toString(), previousImport.isStatic()) == newImportSection) {
                 // Append an import to the end of the previous section.
                 editPosition.line--;
             } else {

--- a/src/main/java/org/javacs/imports/SectionedImportOrderHelper.java
+++ b/src/main/java/org/javacs/imports/SectionedImportOrderHelper.java
@@ -39,6 +39,15 @@ class SectionedImportOrderHelper {
             return List.of();
         }
 
+        // No need to import classes in the same package.
+        var packageTree = root.getPackage();
+        if (packageTree != null) {
+            String packageName = packageTree.getPackageName().toString();
+            if (className.startsWith(packageName + ".") && !className.substring(packageName.length() + 1).contains(".")) {
+                return List.of();
+            }
+        }
+
         // If there is already an import, do not insert one.
         for (var i : imports) {
             String importedClassName = i.getQualifiedIdentifier().toString();
@@ -55,7 +64,6 @@ class SectionedImportOrderHelper {
 
         // Special logic to handle the case of no imports yet.
         if (imports.isEmpty()) {
-            var packageTree = root.getPackage();
             if (packageTree == null) {
                 // There is even no package declaration.
                 return List.of(new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), importCode));

--- a/src/main/java/org/javacs/imports/SimpleAutoImportProvider.java
+++ b/src/main/java/org/javacs/imports/SimpleAutoImportProvider.java
@@ -1,0 +1,26 @@
+package org.javacs.imports;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.util.SourcePositions;
+import java.util.List;
+import javax.tools.Diagnostic;
+import org.javacs.lsp.Position;
+import org.javacs.lsp.Range;
+import org.javacs.lsp.TextEdit;
+
+/**
+ * The default import order that simply sorts imports.
+ */
+public class SimpleAutoImportProvider implements AutoImportProvider {
+    public static final SimpleAutoImportProvider INSTANCE = new SimpleAutoImportProvider();
+
+    private final SectionedImportOrderHelper helper = new SectionedImportOrderHelper((className) -> 0);
+
+    private SimpleAutoImportProvider() {}
+
+    @Override
+    public List<TextEdit> addImport(String className, CompilationUnitTree root, SourcePositions sourcePositions) {
+        return helper.addImport(className, root, sourcePositions);
+    }
+}

--- a/src/main/java/org/javacs/imports/SimpleAutoImportProvider.java
+++ b/src/main/java/org/javacs/imports/SimpleAutoImportProvider.java
@@ -15,7 +15,7 @@ import org.javacs.lsp.TextEdit;
 public class SimpleAutoImportProvider implements AutoImportProvider {
     public static final SimpleAutoImportProvider INSTANCE = new SimpleAutoImportProvider();
 
-    private final SectionedImportOrderHelper helper = new SectionedImportOrderHelper((className) -> 0);
+    private final SectionedImportOrderHelper helper = new SectionedImportOrderHelper((className, isStatic) -> 0);
 
     private SimpleAutoImportProvider() {}
 

--- a/src/main/java/org/javacs/rewrite/AddImport.java
+++ b/src/main/java/org/javacs/rewrite/AddImport.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import org.javacs.CompilerProvider;
 import org.javacs.ParseTask;
+import org.javacs.imports.AutoImportProvider;
 import org.javacs.lsp.Position;
 import org.javacs.lsp.Range;
 import org.javacs.lsp.TextEdit;
@@ -13,50 +14,18 @@ import org.javacs.lsp.TextEdit;
 public class AddImport implements Rewrite {
     final Path file;
     final String className;
+    final AutoImportProvider autoImportProvider;
 
-    public AddImport(Path file, String className) {
+    public AddImport(Path file, String className, AutoImportProvider autoImportProvider) {
         this.file = file;
         this.className = className;
+        this.autoImportProvider = autoImportProvider;
     }
 
     @Override
     public Map<Path, TextEdit[]> rewrite(CompilerProvider compiler) {
         var task = compiler.parse(file);
-        var point = insertPosition(task);
-        var text = "import " + className + ";\n";
-        TextEdit[] edits = {new TextEdit(new Range(point, point), text)};
-        return Map.of(file, edits);
-    }
-
-    private Position insertPosition(ParseTask task) {
-        var imports = task.root.getImports();
-        for (var i : imports) {
-            var next = i.getQualifiedIdentifier().toString();
-            if (className.compareTo(next) < 0) {
-                return insertBefore(task, i);
-            }
-        }
-        if (!imports.isEmpty()) {
-            var last = imports.get(imports.size() - 1);
-            return insertAfter(task, last);
-        }
-        if (task.root.getPackage() != null) {
-            return insertAfter(task, task.root.getPackage());
-        }
-        return new Position(0, 0);
-    }
-
-    private Position insertBefore(ParseTask task, Tree i) {
-        var pos = Trees.instance(task.task).getSourcePositions();
-        var offset = pos.getStartPosition(task.root, i);
-        var line = (int) task.root.getLineMap().getLineNumber(offset);
-        return new Position(line - 1, 0);
-    }
-
-    private Position insertAfter(ParseTask task, Tree i) {
-        var pos = Trees.instance(task.task).getSourcePositions();
-        var offset = pos.getStartPosition(task.root, i);
-        var line = (int) task.root.getLineMap().getLineNumber(offset);
-        return new Position(line, 0);
+        var edits = autoImportProvider.addImport(className, task.root, Trees.instance(task.task).getSourcePositions());
+        return Map.of(file, edits.toArray(new TextEdit[0]));
     }
 }

--- a/src/test/examples/maven-project/src/com/example/AutoImportTest1.java
+++ b/src/test/examples/maven-project/src/com/example/AutoImportTest1.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class AutoImportTest1 {}

--- a/src/test/examples/maven-project/src/com/example/AutoImportTest2.java
+++ b/src/test/examples/maven-project/src/com/example/AutoImportTest2.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class AutoImportTest2 {}

--- a/src/test/examples/maven-project/src/com/example/AutoImportTest3.java
+++ b/src/test/examples/maven-project/src/com/example/AutoImportTest3.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class AutoImportTest3 {}

--- a/src/test/examples/maven-project/src/com/example/AutoImportTest4.java
+++ b/src/test/examples/maven-project/src/com/example/AutoImportTest4.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class AutoImportTest4 {}

--- a/src/test/examples/maven-project/src/com/example/AutoImportTest5.java
+++ b/src/test/examples/maven-project/src/com/example/AutoImportTest5.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class AutoImportTest5 {}

--- a/src/test/examples/maven-project/src/com/example/AutoImportTestStatic.java
+++ b/src/test/examples/maven-project/src/com/example/AutoImportTestStatic.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class AutoImportTestStatic {
+    public static final String CONSTANT = "CONSTANT";
+}

--- a/src/test/examples/maven-project/src/org/javacs/imports/MultipleSections.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/MultipleSections.java
@@ -1,0 +1,9 @@
+package org.javacs.imports;
+
+import com.example.AutoImportTest2;
+import com.example.AutoImportTest4;
+
+import java.util.List;
+import java.util.Map;
+
+public class MultipleSections {}

--- a/src/test/examples/maven-project/src/org/javacs/imports/MultipleSections.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/MultipleSections.java
@@ -1,5 +1,7 @@
 package org.javacs.imports;
 
+import static com.example.AutoImportTestStatic.CONSTANT;
+
 import com.example.AutoImportTest2;
 import com.example.AutoImportTest4;
 

--- a/src/test/examples/maven-project/src/org/javacs/imports/MultipleSections.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/MultipleSections.java
@@ -1,7 +1,5 @@
 package org.javacs.imports;
 
-import static com.example.AutoImportTestStatic.CONSTANT;
-
 import com.example.AutoImportTest2;
 import com.example.AutoImportTest4;
 

--- a/src/test/examples/maven-project/src/org/javacs/imports/NoImport.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/NoImport.java
@@ -1,0 +1,3 @@
+package org.javacs.imports;
+
+public class NoImport {}

--- a/src/test/examples/maven-project/src/org/javacs/imports/NoPackage.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/NoPackage.java
@@ -1,0 +1,3 @@
+// There is even no package declaration.
+
+public class NoPackage {}

--- a/src/test/examples/maven-project/src/org/javacs/imports/SingleSection.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/SingleSection.java
@@ -1,0 +1,6 @@
+package org.javacs.imports;
+
+import com.example.AutoImportTest2;
+import com.example.AutoImportTest4;
+
+public class SingleSection {}

--- a/src/test/examples/maven-project/src/org/javacs/imports/StaticImports.java
+++ b/src/test/examples/maven-project/src/org/javacs/imports/StaticImports.java
@@ -1,0 +1,5 @@
+package org.javacs.imports;
+
+import static com.example.AutoImportTestStatic.CONSTANT;
+
+public class StaticImports {}

--- a/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
+++ b/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
@@ -1,0 +1,120 @@
+package org.javacs.imports;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import com.sun.source.util.Trees;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.javacs.CompilerProvider;
+import org.javacs.LanguageServerFixture;
+import org.javacs.lsp.TextEdit;
+import org.junit.Test;
+
+public class ChromiumAutoImportProviderTest {
+    private static final CompilerProvider compiler = LanguageServerFixture.getCompilerProvider();
+
+    private List<String> addImport(String fileName, String className) {
+        var path = LanguageServerFixture.DEFAULT_WORKSPACE_ROOT
+                .resolve("src/org/javacs/imports")
+                .resolve(fileName)
+                .toAbsolutePath();
+        var task = compiler.parse(path);
+        var edits = ChromiumAutoImportProvider.INSTANCE.addImport(className, task.root, Trees.instance(task.task).getSourcePositions());
+        return edits.stream().map(TextEdit::toString).collect(Collectors.toList());
+    }
+
+    @Test
+    public void noPackage() {
+        var edits = addImport("NoPackage.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("0,0-0,0/import com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void noImport() {
+        var edits = addImport("NoImport.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("1,0-1,0/\nimport com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void singleSectionFirst() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest1");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("2,0-2,0/import com.example.AutoImportTest1;\n"));
+    }
+
+    @Test
+    public void singleSectionMiddle() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("3,0-3,0/import com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void singleSectionLast() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest5");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest5;\n"));
+    }
+
+    @Test
+    public void multipleSectionsFirst() {
+        var edits = addImport("MultipleSections.java", "com.example.AutoImportTest1");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("2,0-2,0/import com.example.AutoImportTest1;\n"));
+    }
+
+    @Test
+    public void multipleSectionsMiddle() {
+        var edits = addImport("MultipleSections.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("3,0-3,0/import com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void multipleSectionsLast() {
+        var edits = addImport("MultipleSections.java", "com.example.AutoImportTest5");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest5;\n"));
+    }
+
+    @Test
+    public void newSectionFirst() {
+        var edits = addImport("MultipleSections.java", "android.Example");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("2,0-2,0/import android.Example;\n\n"));
+    }
+
+    @Test
+    public void newSectionMiddle() {
+        var edits = addImport("MultipleSections.java", "dalvik.Example");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("5,0-5,0/import dalvik.Example;\n\n"));
+    }
+
+    @Test
+    public void newSectionLast() {
+        var edits = addImport("MultipleSections.java", "javax.Example");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("7,0-7,0/\nimport javax.Example;\n"));
+    }
+
+    @Test
+    public void alreadyImported() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest4");
+        assertThat(edits, hasSize(0));
+    }
+}

--- a/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
+++ b/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
@@ -69,7 +69,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "com.example.AutoImportTest1");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("2,0-2,0/import com.example.AutoImportTest1;\n"));
+        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest1;\n"));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "com.example.AutoImportTest3");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("3,0-3,0/import com.example.AutoImportTest3;\n"));
+        assertThat(edit, equalTo("5,0-5,0/import com.example.AutoImportTest3;\n"));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "com.example.AutoImportTest5");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest5;\n"));
+        assertThat(edit, equalTo("6,0-6,0/import com.example.AutoImportTest5;\n"));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "android.Example");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("2,0-2,0/import android.Example;\n\n"));
+        assertThat(edit, equalTo("4,0-4,0/import android.Example;\n\n"));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "dalvik.Example");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("5,0-5,0/import dalvik.Example;\n\n"));
+        assertThat(edit, equalTo("7,0-7,0/import dalvik.Example;\n\n"));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "javax.Example");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("7,0-7,0/\nimport javax.Example;\n"));
+        assertThat(edit, equalTo("9,0-9,0/\nimport javax.Example;\n"));
     }
 
     @Test

--- a/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
+++ b/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
@@ -69,7 +69,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "com.example.AutoImportTest1");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest1;\n"));
+        assertThat(edit, equalTo("2,0-2,0/import com.example.AutoImportTest1;\n"));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "com.example.AutoImportTest3");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("5,0-5,0/import com.example.AutoImportTest3;\n"));
+        assertThat(edit, equalTo("3,0-3,0/import com.example.AutoImportTest3;\n"));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "com.example.AutoImportTest5");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("6,0-6,0/import com.example.AutoImportTest5;\n"));
+        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest5;\n"));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "android.Example");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("4,0-4,0/import android.Example;\n\n"));
+        assertThat(edit, equalTo("2,0-2,0/import android.Example;\n\n"));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "dalvik.Example");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("7,0-7,0/import dalvik.Example;\n\n"));
+        assertThat(edit, equalTo("5,0-5,0/import dalvik.Example;\n\n"));
     }
 
     @Test
@@ -109,7 +109,15 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "javax.Example");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("9,0-9,0/\nimport javax.Example;\n"));
+        assertThat(edit, equalTo("7,0-7,0/\nimport javax.Example;\n"));
+    }
+
+    @Test
+    public void ignoreStaticImports() {
+        var edits = addImport("StaticImports.java", "android.Example");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("3,0-3,0/\nimport android.Example;\n"));
     }
 
     @Test
@@ -129,6 +137,6 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("MultipleSections.java", "org.javacs.imports.child.ChildPackage");
         assertThat(edits, hasSize(1));
         var edit = edits.get(0);
-        assertThat(edit, equalTo("7,0-7,0/import org.javacs.imports.child.ChildPackage;\n\n"));
+        assertThat(edit, equalTo("5,0-5,0/import org.javacs.imports.child.ChildPackage;\n\n"));
     }
 }

--- a/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
+++ b/src/test/java/org/javacs/imports/ChromiumAutoImportProviderTest.java
@@ -117,4 +117,18 @@ public class ChromiumAutoImportProviderTest {
         var edits = addImport("SingleSection.java", "com.example.AutoImportTest4");
         assertThat(edits, hasSize(0));
     }
+
+    @Test
+    public void samePackage() {
+        var edits = addImport("MultipleSections.java", "org.javacs.imports.SamePackage");
+        assertThat(edits, hasSize(0));
+    }
+
+    @Test
+    public void childPackage() {
+        var edits = addImport("MultipleSections.java", "org.javacs.imports.child.ChildPackage");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("7,0-7,0/import org.javacs.imports.child.ChildPackage;\n\n"));
+    }
 }

--- a/src/test/java/org/javacs/imports/SimpleAutoImportProviderTest.java
+++ b/src/test/java/org/javacs/imports/SimpleAutoImportProviderTest.java
@@ -1,0 +1,72 @@
+package org.javacs.imports;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import com.sun.source.util.Trees;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.javacs.CompilerProvider;
+import org.javacs.LanguageServerFixture;
+import org.javacs.lsp.TextEdit;
+import org.junit.Test;
+
+public class SimpleAutoImportProviderTest {
+    private static final CompilerProvider compiler = LanguageServerFixture.getCompilerProvider();
+
+    private List<String> addImport(String fileName, String className) {
+        var path = LanguageServerFixture.DEFAULT_WORKSPACE_ROOT
+                .resolve("src/org/javacs/imports")
+                .resolve(fileName)
+                .toAbsolutePath();
+        var task = compiler.parse(path);
+        var edits = ChromiumAutoImportProvider.INSTANCE.addImport(className, task.root, Trees.instance(task.task).getSourcePositions());
+        return edits.stream().map(TextEdit::toString).collect(Collectors.toList());
+    }
+
+    @Test
+    public void noPackage() {
+        var edits = addImport("NoPackage.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("0,0-0,0/import com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void noImport() {
+        var edits = addImport("NoImport.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("1,0-1,0/\nimport com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void addFirst() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest1");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("2,0-2,0/import com.example.AutoImportTest1;\n"));
+    }
+
+    @Test
+    public void addMiddle() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest3");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("3,0-3,0/import com.example.AutoImportTest3;\n"));
+    }
+
+    @Test
+    public void addLast() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest5");
+        assertThat(edits, hasSize(1));
+        var edit = edits.get(0);
+        assertThat(edit, equalTo("4,0-4,0/import com.example.AutoImportTest5;\n"));
+    }
+
+    @Test
+    public void alreadyImported() {
+        var edits = addImport("SingleSection.java", "com.example.AutoImportTest4");
+        assertThat(edits, hasSize(0));
+    }
+}


### PR DESCRIPTION
This patch introduces a new interface to represent the import order. We also provide its two implementations: the simple one (all imports in a single section with lexicographical order), and the one conforming to the Chromium Java style guide (which I use for my project).

The interface is used in two places: the existing logic to add an import as a quick fix, and the new logic to add an import on completing class names.

The style can be configured by user settings.

Fixes #96