### PR TITLE
Refactor: Replace deprecated org.junit.Assert.assertThat

### DIFF
--- a/src/test/java/org/javacs/ArtifactTest.java
+++ b/src/test/java/org/javacs/ArtifactTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/org/javacs/ClassesTest.java
+++ b/src/test/java/org/javacs/ClassesTest.java
@@ -1,7 +1,8 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.nio.file.FileSystems;

--- a/src/test/java/org/javacs/CodeActionTest.java
+++ b/src/test/java/org/javacs/CodeActionTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/javacs/CodeLensTest.java
+++ b/src/test/java/org/javacs/CodeLensTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/javacs/CompletionsScopesTest.java
+++ b/src/test/java/org/javacs/CompletionsScopesTest.java
@@ -2,7 +2,7 @@ package org.javacs;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/org/javacs/CompletionsTest.java
+++ b/src/test/java/org/javacs/CompletionsTest.java
@@ -1,7 +1,8 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/test/java/org/javacs/FileEncodingTest.java
+++ b/src/test/java/org/javacs/FileEncodingTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Paths;
 import java.util.Set;

--- a/src/test/java/org/javacs/FileStoreTest.java
+++ b/src/test/java/org/javacs/FileStoreTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Set;
 import org.junit.Before;

--- a/src/test/java/org/javacs/FindReferencesTest.java
+++ b/src/test/java/org/javacs/FindReferencesTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/javacs/FindSrcZipTest.java
+++ b/src/test/java/org/javacs/FindSrcZipTest.java
@@ -1,7 +1,8 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/test/java/org/javacs/GotoTest.java
+++ b/src/test/java/org/javacs/GotoTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URI;
 import java.nio.file.Path;

--- a/src/test/java/org/javacs/HoverTest.java
+++ b/src/test/java/org/javacs/HoverTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.StringJoiner;
 import org.javacs.lsp.*;

--- a/src/test/java/org/javacs/IncrementalCompileTest.java
+++ b/src/test/java/org/javacs/IncrementalCompileTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.util.*;

--- a/src/test/java/org/javacs/InferBazelConfigTest.java
+++ b/src/test/java/org/javacs/InferBazelConfigTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Paths;
 import org.junit.Ignore;

--- a/src/test/java/org/javacs/InferConfigTest.java
+++ b/src/test/java/org/javacs/InferConfigTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/test/java/org/javacs/MarkdownHelperTest.java
+++ b/src/test/java/org/javacs/MarkdownHelperTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/org/javacs/SearchTest.java
+++ b/src/test/java/org/javacs/SearchTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.net.URI;

--- a/src/test/java/org/javacs/SemanticColorsTest.java
+++ b/src/test/java/org/javacs/SemanticColorsTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.gson.JsonElement;
 import java.nio.file.Paths;

--- a/src/test/java/org/javacs/SignatureHelpTest.java
+++ b/src/test/java/org/javacs/SignatureHelpTest.java
@@ -1,7 +1,8 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/javacs/SourceFileManagerTest.java
+++ b/src/test/java/org/javacs/SourceFileManagerTest.java
@@ -1,7 +1,8 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.Charset;

--- a/src/test/java/org/javacs/StringSearchTest.java
+++ b/src/test/java/org/javacs/StringSearchTest.java
@@ -1,7 +1,9 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.nio.file.Paths;
 import org.javacs.lsp.DidChangeTextDocumentParams;

--- a/src/test/java/org/javacs/WarningsTest.java
+++ b/src/test/java/org/javacs/WarningsTest.java
@@ -1,7 +1,7 @@
 package org.javacs;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/src/test/java/org/javacs/lsp/LanguageServerTest.java
+++ b/src/test/java/org/javacs/lsp/LanguageServerTest.java
@@ -1,7 +1,7 @@
 package org.javacs.lsp;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.PipedInputStream;

--- a/src/test/java/org/javacs/lsp/LspTest.java
+++ b/src/test/java/org/javacs/lsp/LspTest.java
@@ -1,7 +1,7 @@
 package org.javacs.lsp;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;

--- a/src/test/java/org/javacs/rewrite/RewriteTest.java
+++ b/src/test/java/org/javacs/rewrite/RewriteTest.java
@@ -1,7 +1,8 @@
 package org.javacs.rewrite;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.nio.file.Path;
 import org.javacs.CompilerProvider;


### PR DESCRIPTION
I replaced all usages of `org.junit.Assert.assertThat` with the recommended `org.hamcrest.MatcherAssert.assertThat`.

This change updates the import statements in the affected test files.