### PR TITLE
handle paths with whitespace in Windows launchers

### DIFF
--- a/dist/debug_adapter_windows.cmd
+++ b/dist/debug_adapter_windows.cmd
@@ -1,3 +1,3 @@
 @echo off
-call %~dp0\launch_windows.cmd org.javacs.debug.JavaDebugServer %*
+call "%~dp0\launch_windows.cmd" org.javacs.debug.JavaDebugServer %*
 

--- a/dist/lang_server_windows.cmd
+++ b/dist/lang_server_windows.cmd
@@ -1,3 +1,3 @@
 @echo off
-call %~dp0\launch_windows.cmd org.javacs.Main %*
+call "%~dp0\launch_windows.cmd" org.javacs.Main %*
 


### PR DESCRIPTION
When installed in a path containing whitespace, invoking the server from my editor returns this:
```
'C:\Users\Firstname' is not recognized as an internal or external command,
operable program or batch file.
```
My user directory is like:  `C:\Users\Firstname Lastname`.
Quoting the path (from `%~dp0`) resolves this and shouldn't cause problems with paths that already worked.
