### PR TITLE
do not emit unused_throws on abstract or native methods

### DIFF
--- a/src/main/java/org/javacs/markup/WarnNotThrown.java
+++ b/src/main/java/org/javacs/markup/WarnNotThrown.java
@@ -36,6 +36,10 @@ class WarnNotThrown extends TreePathScanner<Void, Map<TreePath, String>> {
 
     @Override
     public Void visitMethod(MethodTree t, Map<TreePath, String> notThrown) {
+        // Skip on abstract or native
+        if (t.getBody() == null) {
+            return null;
+        }
         // Create a new method scope
         var pushDeclared = declaredExceptions;
         var pushObserved = observedExceptions;

--- a/src/test/examples/maven-project/src/org/javacs/warn/Unused.java
+++ b/src/test/examples/maven-project/src/org/javacs/warn/Unused.java
@@ -44,4 +44,14 @@ class Unused {
     }
 
     void notActuallyThrown() throws Exception { }
+
+    interface Throws {
+        void interfaceThrows() throws Exception;
+    }
+
+    abstract class AbstractThrows {
+        abstract void abstractThrows() throws Exception;
+    }
+
+    native void nativeThrows() throws Exception;
 }

--- a/src/test/java/org/javacs/WarningsTest.java
+++ b/src/test/java/org/javacs/WarningsTest.java
@@ -92,7 +92,7 @@ public class WarningsTest {
         assertThat(errors, hasItem("unused_method(30)")); // private void unusedMutuallyRecursive1() { ... }
         assertThat(errors, hasItem("unused_method(34)")); // private void unusedMutuallyRecursive2() { ... }
         assertThat(errors, not(hasItem("unused_method(38)"))); // private int usedByUnusedVar() { ... }
-        assertThat(errors, not(hasItem("unused_throw(46)"))); // void notActuallyThrown() throws Exception { }
+        assertThat(errors, hasItem("unused_throws(46)")); // void notActuallyThrown() throws Exception { }
     }
 
     @Test

--- a/src/test/java/org/javacs/WarningsTest.java
+++ b/src/test/java/org/javacs/WarningsTest.java
@@ -93,6 +93,9 @@ public class WarningsTest {
         assertThat(errors, hasItem("unused_method(34)")); // private void unusedMutuallyRecursive2() { ... }
         assertThat(errors, not(hasItem("unused_method(38)"))); // private int usedByUnusedVar() { ... }
         assertThat(errors, hasItem("unused_throws(46)")); // void notActuallyThrown() throws Exception { }
+        assertThat(errors, not(hasItem("unused_throws(49)"))); // void interfaceThrows() throws Exception;
+        assertThat(errors, not(hasItem("unused_throws(53)"))); // abstract void abstractThrows() throws Exception;
+        assertThat(errors, not(hasItem("unused_throws(56)"))); // native void nativeThrows() throws Exception;
     }
 
     @Test


### PR DESCRIPTION
Skip unused_throws check if method implementation is absent