### PR TITLE
fix(RangeHelper): fix calculation of position offset

### DIFF
--- a/src/main/java/org/javacs/markup/RangeHelper.java
+++ b/src/main/java/org/javacs/markup/RangeHelper.java
@@ -8,11 +8,11 @@ class RangeHelper {
     static Range range(CompilationUnitTree root, long start, long end) {
         var lines = root.getLineMap();
         var startLine = (int) lines.getLineNumber(start);
-        var startColumn = (int) lines.getColumnNumber(start);
-        var startPos = new Position(startLine - 1, startColumn - 1);
+        var startLineFrom = lines.getStartPosition(startLine);
+        var startPos = new Position(startLine - 1, (int)(start - startLineFrom));
         var endLine = (int) lines.getLineNumber(end);
-        var endColumn = (int) lines.getColumnNumber(end);
-        var endPos = new Position(endLine - 1, endColumn - 1);
+        var endLineFrom = lines.getStartPosition(endLine);
+        var endPos = new Position(endLine - 1, (int)(end - endLineFrom));
         return new Range(startPos, endPos);
     }
 }


### PR DESCRIPTION
In LSP, position is expressed by line and character offset, not column offset. This fixes position reporting if line contains multi-column character, like tabs.