### PR TITLE
Fix ReusableLog.clear() access privileges for newer JDK compilation

### DIFF
--- a/src/main/java/org/javacs/ReusableCompiler.java
+++ b/src/main/java/org/javacs/ReusableCompiler.java
@@ -166,7 +166,7 @@ class ReusableCompiler {
             put(JavaCompiler.compilerKey, ReusableJavaCompiler.factory);
         }
 
-        public void clear() {
+    void clear() {
             drop(Arguments.argsKey);
             drop(DiagnosticListener.class);
             drop(Log.outKey);
@@ -263,7 +263,7 @@ class ReusableCompiler {
                 this.context = context;
             }
 
-            void clear() {
+            public void clear() {
                 recorded.clear();
                 sourceMap.clear();
                 nerrors = 0;

--- a/src/main/java/org/javacs/ReusableCompiler.java
+++ b/src/main/java/org/javacs/ReusableCompiler.java
@@ -166,7 +166,7 @@ class ReusableCompiler {
             put(JavaCompiler.compilerKey, ReusableJavaCompiler.factory);
         }
 
-        void clear() {
+        public void clear() {
             drop(Arguments.argsKey);
             drop(DiagnosticListener.class);
             drop(Log.outKey);


### PR DESCRIPTION
Newer JDK versions enforce stricter override visibility check boundaries. Added the missing `public` modifier to line 169 of ReusableLog.clear() to resolve compilation failures on modern environments.