### PR TITLE
Fix: Added guard for jdk auto download

### DIFF
--- a/scripts/link_linux.sh
+++ b/scripts/link_linux.sh
@@ -6,6 +6,12 @@ set -e
 # Set env variables to build with mac toolchain but linux target
 JAVA_HOME="./jdks/linux/jdk-21"
 
+
+# Check if download exists/completed if not completed download before building
+if [ ! -d "$JAVA_HOME" ]; then
+    ./scripts/download_linux_jdk.sh
+fi
+
 # Build in dist/linux
 rm -rf dist/linux
 ${JAVA_HOME}/bin/jlink \


### PR DESCRIPTION
# link_linux: download JDK automatically if missing
Trying to MasonInstall java-language-server on Neovim gave the error:

```Bash
         ◍ java-language-server
      ▼ Displaying full log
        Cloning git repository "https://github.com/georgewfraser/java-language-server.git"…
        Cloning into '.'...
        From https://github.com/georgewfraser/java-language-server
         * tag               v0.2.39    -> FETCH_HEAD
        + ./scripts/link_linux.sh
        Error: This JDK does not support linking from the current run-time image
        spawn: bash failed with exit code 2 and signal 0. Cloning into '.'...
        From https://github.com/georgewfraser/java-language-server
         * tag               v0.2.39    -> FETCH_HEAD
        + ./scripts/link_linux.sh
```
Because Mason is running ./script/link_linux.sh which doesn't auto download the jdk before linking and crahses
to fix added :
```Bash
if [ ! -d "$JAVA_HOME" ]; then
    ./scripts/download_linux_jdk.sh
fi
```
Added a guard that downloads the jdk automatically if the target
directory doesn't exist, making the script self-contained.
